### PR TITLE
Update progressbar output

### DIFF
--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -1,13 +1,12 @@
+use indicatif::ProgressBar;
+use log::{debug, info};
+use semver::{Version, VersionReq};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::Command;
-
-use indicatif::ProgressBar;
-use log::{debug, info};
-use semver::{Version, VersionReq};
 
 use crate::{download_unpack_and_all_that_stuff, Gradle, Java, NoClap, Node};
 use crate::maven::Maven;
@@ -155,6 +154,8 @@ pub async fn prep(executor: &dyn Executor, input: &AppInput, pb: &ProgressBar) -
 
     let name = executor.get_name();
 
+    pb.set_prefix(String::from(name));
+
     match app_path {
         Some(app_path_ok) if app_path_ok.bin.exists() => return Ok(app_path_ok),
         _ => {
@@ -162,10 +163,10 @@ pub async fn prep(executor: &dyn Executor, input: &AppInput, pb: &ProgressBar) -
         }
     }
 
-    pb.set_message(format!("{name}: Fetching versions"));
+    pb.set_message(format!("Fetching versions"));
 
     let urls = executor.get_download_urls(input).await;
-    pb.set_message(format!("{name}: {} versions", &urls.len()));
+    pb.set_message(format!("{} versions", &urls.len()));
     debug!( "{:?}", urls);
 
     if urls.is_empty() {
@@ -252,7 +253,7 @@ pub async fn prep(executor: &dyn Executor, input: &AppInput, pb: &ProgressBar) -
     let url = urls_match.first();
 
     let url_string = if let Some(url) = url {
-        pb.set_message(format!("{name}: {}", url.version.clone().map(|v| v.to_string()).unwrap_or("".to_string())));
+        pb.set_prefix(format!("{name} {}", url.version.clone().map(|v| v.to_string()).unwrap_or("".to_string())));
         &url.download_url
     } else {
         ""

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -1,14 +1,12 @@
-use std::collections::HashMap;
-use std::fmt::Write;
-use std::fs;
-use std::process::ExitCode;
-
+use bloody_indiana_jones::download_unpack_and_all_that_stuff;
 use futures_util::future::join_all;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use log::{debug, info};
 use semver::VersionReq;
-
-use bloody_indiana_jones::download_unpack_and_all_that_stuff;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::fs;
+use std::process::ExitCode;
 
 use crate::bloody_indiana_jones::download;
 use crate::executor::{AppInput, Executor, ExecutorCmd, prep, try_run};
@@ -134,7 +132,7 @@ async fn main() -> ExitCode {
 
             let alles = executors.iter().enumerate().map(|(i, x)| {
                 let pb = m.insert(i, ProgressBar::new(1));
-                pb.set_style(ProgressStyle::with_template("{spinner:.green} {msg} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                pb.set_style(ProgressStyle::with_template("{prefix:.bold} {spinner:.green} {msg} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
                     .unwrap()
                     .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
                     .progress_chars("#>-"));


### PR DESCRIPTION
Extract downloads in parallel. Done by wrapping tokio::task::span_blocking. Not bestest solution, but best I managed. Use prefix for name and name + version in progressbar.

![image](https://github.com/eirikb/gg/assets/241706/7c08a84c-f049-41ac-8f23-c09e029122dd)
