### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,24 @@
 [![Release](https://badgen.net/github/release/eirikb/gg)](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
 
 [**[Changelog]**](https://github.com/eirikb/gg/releases)
+[**[Download]**](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
 
-![image](https://github.com/eirikb/gg/assets/241706/b671f15e-23a3-4adb-9488-272e35f6a686)
+![image](https://github.com/eirikb/gg/assets/241706/2fc55830-ba2c-4ba8-8501-8013ed000444)
 
-![image](https://github.com/eirikb/gg/assets/241706/b69dde63-6f9e-4726-b1e9-bc25bfd0b786)
+![image](https://github.com/eirikb/gg/assets/241706/2594717d-6e3b-4773-a7db-4d951ec0aa0c)
 
 gg.cmd is a cross-platform and cross-architecture command-line interface (CLI) that acts as an executable wrapper for
 various tools such as Gradle, JDK/JVM, Node.js, and Java. It requires minimal dependencies and is similar in
 functionality to gradlew.
 
-Install with bash:
+Install with bash (wget):
 > wget gg.eirikb.no/gg.cmd
 
+Install with bash (curl):
+> curl gg.eirikb.no > gg.cmd
+
 Install with PowerShell:
-> wget gg.eirikb.no/gg.cmd -OutFile gg.cmd
+> wget gg.eirikb.no -OutFile gg.cmd
 
 or  
 [Download the latest release](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
@@ -25,7 +29,7 @@ or
 **Install?**  
 The concept involves placing a copy of gg.cmd in the root directory of your project.  
 This is similar to what you would do with `gradlew` or `mvnw`, except this method is applicable to multiple tools.  
-As a result, your colleagues would not have to install anything on their host machines."
+As a result, your colleagues would not have to install anything on their host machines.
 
 ## Features
 

--- a/src/README.md
+++ b/src/README.md
@@ -17,8 +17,9 @@ Roughly:
 * **Stage 3**: Binary for each arch/os/variant for downloading stage 4. For example one for Linux x64 glibc, and another
   for Linux x64 musl. Building a static version with musl would be too big.
   Cosmopolitan does not (at writing time) support ARM.
-* ** Stage 4**: rust-based CLI. Does the actual logic (download, extract, execute). Hosted externally. One for each
+* **Stage 4**: rust-based CLI. Does the actual logic (download, extract, execute). Hosted externally. One for each
   OS/arch.
+
 
 
 

--- a/src/README.md
+++ b/src/README.md
@@ -20,6 +20,9 @@ Roughly:
 * **Stage 4**: rust-based CLI. Does the actual logic (download, extract, execute). Hosted externally. One for each
   OS/arch.
 
-
+The url _ggcmd.z13.web.core.windows.net_ littered around is storage for gg.eirikb.no.  
+The only reason I use the direct URL instead of gg.eirikb.no is because then it won't go
+through the CDN, which is, ironically, more expensive for me at the moment.  
+This host will only be part of specific versions of gg.cmd, and future versions can use gg.eirikb.no insetad just fine.
 
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,18 @@
 Stages?  
 gg.cmd is split into different stages.
 
+**Contents of gg.cmd**
+![image](https://github.com/eirikb/gg/assets/241706/4d93262a-5029-4e04-8924-56c70af42ff7)
+
+**Output of running gg.cmd (before stage4 is downloaded)**
+![image](https://github.com/eirikb/gg/assets/241706/90eea521-8223-4b44-b7c2-ed9356951985)
+
+**After running gg.cmd and getting stage4**
+![image](https://github.com/eirikb/gg/assets/241706/1e4e2c4f-35b9-4449-aed5-83bf9042a6ea)
+
+**After installing deno**:
+![image](https://github.com/eirikb/gg/assets/241706/fe511e00-223d-4ec0-8588-21506a32e8c2)
+
 The gg.cmd-file itself is built up like this:
 
 1. stage1 batch script

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> ExitCode {
             ExitCode::from(1)
         };
     } else {
-        println!("Missing command. Try -h");
+        println!("Missing command. Try help");
         print_help(ver);
         ExitCode::from(1)
     };

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -22,7 +22,7 @@ mod checker;
 mod barus;
 
 fn print_help(ver: &str) {
-    println!(r"gg.cmd
+    println!(r"
 https://github.com/eirikb/gg
 
 Version: {ver}


### PR DESCRIPTION
New download URLs. gg.eirikb.no will now directly download gg.cmd.  
Updated readme of stages (src) to show pictures of how it works. A bit less confusing.