### PR TITLE
Dash in commands

### DIFF
--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -30,16 +30,16 @@ Version: {ver}
 Usage: ./gg.cmd [options] <executable name>@<version>:<dependent executable name>@<version> [program arguments]
 
 Options:
-    -v             Info output
-    -vv            Debug output
-    -vvv           Trace output
-    -w             Even more output
-    -V             Print version
+    -v              Info output
+    -vv             Debug output
+    -vvv            Trace output
+    -w              Even more output
+    -V              Print version
 
 Built in commands:
-    update         Update gg.cmd
-    help           Print help
-    check          Check for updates
+    update          Update gg.cmd
+    help            Print help
+    check           Check for updates
     check-update    Check for updates and update if available
     clean-cache     Clean cache
 

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -40,8 +40,8 @@ Built in commands:
     update         Update gg.cmd
     help           Print help
     check          Check for updates
-    checkupdate    Check for updates and update if available
-    cacheclean     Clean cache
+    check-update    Check for updates and update if available
+    clean-cache     Clean cache
 
 Examples:
     ./gg.cmd node
@@ -117,11 +117,11 @@ async fn main() -> ExitCode {
                 checker::check(input, false).await;
                 return ExitCode::from(0);
             }
-            "checkupdate" => {
+            "check-update" => {
                 checker::check(input, true).await;
                 return ExitCode::from(0);
             }
-            "cacheclean" => {
+            "clean-cache" => {
                 println!("Cleaning cache");
                 let _ = fs::remove_dir_all(".cache/gg");
                 return ExitCode::from(0);


### PR DESCRIPTION
There is a dash in the commands `check-update` and `clean-cache` now.
![image](https://github.com/eirikb/gg/assets/241706/8b5403ca-c58a-4367-8400-bce7caebe0b1)

This also means @ must be used even for tags only, e.g., `java@-lts`.