### PR TITLE
Strip stage4

### DIFF
--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -81,6 +81,7 @@ jobs:
           cargo build --release --target=${{ matrix.target }}
           find . -type f -name stage4.exe -exec cp {} ../stage4 \;
           find . -type f -name stage4 -exec cp {} ../stage4 \;
+          strip ../stage4
 
 
       - name: Upload artifact


### PR DESCRIPTION
Stripping stage4 makes the binary much smaller.   
This makes the initial download faster.   
For macOS and Windows the difference is not that large, but on Linux it is half-ish size.   
Stripping is fine for this app. I hope.

![image](https://github.com/eirikb/gg/assets/241706/8f953564-5a1f-4f2e-ae20-03ef8ae827ac)
