### PR TITLE
Add JBang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gg.cmd
+# `gg.cmd`
 
 [![gg.cmd](https://github.com/eirikb/gg/actions/workflows/gg.yml/badge.svg)](https://github.com/eirikb/gg/actions/workflows/gg.yml)
 [![Release](https://badgen.net/github/release/eirikb/gg)](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
@@ -10,7 +10,7 @@
 
 ![Image](https://github.com/user-attachments/assets/93876050-9c28-4389-a77c-5a88f5af2811)
 
-gg.cmd is a cross-platform and cross-architecture command-line interface (CLI) that acts as an executable wrapper for
+`gg.cmd` is a cross-platform and cross-architecture command-line interface (CLI) that acts as an executable wrapper for
 various tools such as Gradle, JDK/JVM, Node.js, and Java. It requires minimal dependencies and is similar in
 functionality to gradlew.
 
@@ -23,11 +23,12 @@ Install with bash (curl):
 Install with PowerShell:
 > wget ggcmd.io -OutFile gg.cmd
 
-or  
+or
+
 [Download the latest release](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
 
 **Install?**  
-The concept involves placing a copy of gg.cmd in the root directory of your project.  
+The concept involves placing a copy of `gg.cmd` in the root directory of your project.  
 This is similar to what you would do with `gradlew` or `mvnw`, except this method is applicable to multiple tools.  
 As a result, your colleagues would not have to install anything on their host machines.
 
@@ -46,7 +47,7 @@ Adds every dependency into `PATH` before executing.
 
 ## Usage
 
-Using gg.cmd is easy. Simply place the executable in the root of your project and run it with the `gg.cmd` command
+Using `gg.cmd` is easy. Simply place the executable in the root of your project and run it with the `gg.cmd` command
 followed
 by the desired executable and its required dependencies:
 
@@ -64,13 +65,14 @@ sh gg.cmd npm install
 
 | Logo                                                                                                                          | Commands                         | Depends on | Set environment variables | Available tags                                                                     | Default tags |
 |-------------------------------------------------------------------------------------------------------------------------------|----------------------------------|------------|---------------------------|------------------------------------------------------------------------------------|--------------|
-| <img src="https://user-images.githubusercontent.com/241706/231715452-4e04052a-d13c-4bca-afa5-0bb19239b6f0.png" width="100px"> | **node**<br/>**npm**<br/>**npx** |            |                           | lts                                                                                |
-| <img src="https://user-images.githubusercontent.com/241706/231713381-cc8436bb-ef6e-4aa6-ab5c-66ee0a868201.png" width="100px"> | **gradle**                       | java       |                           |
-| <img src="https://user-images.githubusercontent.com/241706/231713130-ba667ff2-a129-47be-9d06-9e68e6815108.png" width="100px"> | **java**                         |            | JAVA_HOME                 | jdk<br/>jre<br/>lts<br/>sts<br/>mts<br/>ea<br/>ga<br/>headless<br/>headfull<br/>fx | +jdk<br/>+ga |
-| <img src="https://user-images.githubusercontent.com/241706/231999543-61a192f0-7931-495d-a845-fdd855e690e5.png" width="100px"> | **maven**<br/>**mvn**            | java       |                           |                                                                                    |              |
-| <img src="https://github.com/eirikb/gg/assets/241706/4d8be751-4680-4cc8-a939-f7ee6fac841f" width="100px">                     | **openapi**                      | java       |                           | beta                                                                               |              |
+| <img src="https://user-images.githubusercontent.com/241706/231715452-4e04052a-d13c-4bca-afa5-0bb19239b6f0.png" width="100px"> | **node**<br/>**npm**<br/>**npx** |            |                           | lts                                                                                |              |
 | <img src="https://github.com/eirikb/gg/assets/241706/71b42988-bf62-49d3-b675-b2e526b3a8cc" width="100px">                     | **deno**                         |            |                           |                                                                                    |              |
+| <img src="https://user-images.githubusercontent.com/241706/231713381-cc8436bb-ef6e-4aa6-ab5c-66ee0a868201.png" width="100px"> | **gradle**                       | java       |                           |                                                                                    |              |
+| <img src="https://user-images.githubusercontent.com/241706/231999543-61a192f0-7931-495d-a845-fdd855e690e5.png" width="100px"> | **maven**<br/>**mvn**            | java       |                           |                                                                                    |              |
+| <img src="https://www.jbang.dev/assets/images/logo.png" width="50%">                                                          | **jbang**                        | java       |                           |                                                                                    |              |
+| <img src="https://user-images.githubusercontent.com/241706/231713130-ba667ff2-a129-47be-9d06-9e68e6815108.png" width="100px"> | **java**                         |            | JAVA_HOME                 | jdk<br/>jre<br/>lts<br/>sts<br/>mts<br/>ea<br/>ga<br/>headless<br/>headfull<br/>fx | +jdk<br/>+ga |
 | <img src="https://github.com/eirikb/gg/assets/241706/e674f306-ce32-4718-b560-1b454f49e94c" width="100px">                     | **go**                           |            |                           | beta                                                                               |              |
+| <img src="https://github.com/eirikb/gg/assets/241706/4d8be751-4680-4cc8-a939-f7ee6fac841f" width="100px">                     | **openapi**                      | java       |                           | beta                                                                               |              |
 
 ## OS / Arch support table
 
@@ -80,18 +82,12 @@ sh gg.cmd npm install
 | macOS   | &check; |         |
 | Windows | &check; |         |
 
-## gradlew
+## Node
 
-Supports `distributionUrl` in `gradle-wrapper.properties` and  `gradle.properties`.  
-Supports `distributionSha256sum` in `gradle-wrapper.properties`.
+Version from:
 
-You can replace gradlew with a single gg.cmd and can
-delete these files:
-
-* gradle/wrapper/gradle-wrapper.jar
-* gradle/wrapper/gradle-wrapper.properties
-* gradlew
-* gradlew.bat
+* `engines` in `package.json`
+* Contents of `.nvmrc`
 
 ## Gradle
 
@@ -105,12 +101,9 @@ Download URL from:
 * `distributionUrl` in `gradle/wrapper/gradle-wrapper.properties`
 * `distributionUrl` in `gradle.properties`
 
-## Node
+## JBang
 
-Version from:
-
-* `engines` in `package.json`
-* Contents of `.nvmrc`
+The Java version is read from the JBang script using the [`//JAVA magic comment`](https://www.jbang.dev/documentation/guide/latest/javaversions.html).
 
 ## Java
 
@@ -121,12 +114,28 @@ Version from:
 
 ## Examples
 
-Here are a few examples of how gg.cmd can make your life easier:
+Here are a few examples of how `gg.cmd` can make your life easier:
 
 ### Execute gradle
 
 ```bash
 ./gg.cmd gradle build
+```
+
+### Replace gradlew and gradle JARs by `gg.cmd`
+
+You can replace `gradlew` with a single `gg.cmd` and `gradle.properties` and can
+delete these files:
+
+* `gradle/wrapper/gradle-wrapper.jar`
+* `gradle/wrapper/gradle-wrapper.properties`
+* `gradlew`
+* `gradlew.bat`
+
+### Execute JBang
+
+```bash
+./gg.cmd jbang script.java
 ```
 
 ### Execute specific version of Node.js
@@ -154,7 +163,6 @@ Here are a few examples of how gg.cmd can make your life easier:
 cp gg.cmd my-app
 cd my-app
 ./gg.cmd npm start
-
 ```
 
 ## Contributing
@@ -164,4 +172,4 @@ the [GitHub repository](https://github.com/example/gg).
 
 ## License
 
-gg.cmd is licensed under the MIT License. See [LICENSE](LICENSE) for more information.
+`gg.cmd` is licensed under the MIT License. See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
This adds JBang to the README.md

Additionally small refinements:

* `gg.cmd` always in backticks
* Re-oder table to have java grouped together
* Remove doublicate information on gradle supported files
* Move "gradle file removal" to examples