### PR TITLE
New download cleanup approach

### DIFF
--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -493,7 +493,7 @@ pub async fn prep(
 
     let cache_base_dir = std::env::var("GG_CACHE_DIR").unwrap_or_else(|_| ".cache/gg".to_string());
     let cache_path = format!("{cache_base_dir}/{path}");
-    let bloody_indiana_jones = BloodyIndianaJones::new_with_cache_dir(
+    let mut bloody_indiana_jones = BloodyIndianaJones::new_with_cache_dir(
         url_string.to_string(),
         cache_path.clone(),
         &cache_base_dir,


### PR DESCRIPTION
Had issues with cleaning up only the downloaded file, while this can be extracted and whatnot, e.g., tar.gz -> tar -> folder. Instead of using temp location, all is put into downloads, and then to clear it out we can use snapshotting. Basically look at what stuff we have before download, and after whole process of download + extract. It's not bullet proof, but it should work fine enough.