### PR TITLE
Windows: tmp file must be called .cmd for CMD to run it - should work…

### DIFF
--- a/src/stage4/src/updater.rs
+++ b/src/stage4/src/updater.rs
@@ -203,7 +203,7 @@ pub async fn perform_update(ver: &str, force: bool) {
 
     let final_path = env::var("GG_CMD_PATH").unwrap_or_else(|_| "gg.cmd".to_string());
     let final_path = final_path.replace('\\', "/");
-    let temp_path = format!("{}.tmp", final_path);
+    let temp_path = format!("{}.tmp.cmd", final_path);
 
     println!("Updating: {}", final_path);
 


### PR DESCRIPTION
… fine in other shells.