### PR TITLE
Fix all clippy warnings

### DIFF
--- a/src/stage4/src/bloody_indiana_jones.rs
+++ b/src/stage4/src/bloody_indiana_jones.rs
@@ -16,7 +16,7 @@ fn get_file_name(url: &str) -> String {
         .unwrap()
         .path_segments()
         .unwrap()
-        .last()
+        .next_back()
         .unwrap()
         .to_string()
 }
@@ -89,10 +89,10 @@ impl BloodyIndianaJones {
             .get(&self.url)
             .send()
             .await
-            .expect(format!("Failed to get {}", &self.url).as_str());
+            .unwrap_or_else(|_| panic!("Failed to get {}", &self.url));
         let total_size = res
             .content_length()
-            .expect(format!("Failed to get content length from {}", &self.url).as_str());
+            .unwrap_or_else(|| panic!("Failed to get content length from {}", &self.url));
 
         debug!("Total size {:?}", total_size);
 
@@ -104,7 +104,7 @@ impl BloodyIndianaJones {
         debug!("{:?}", &self.file_path);
 
         let mut file = File::create(&self.file_path)
-            .expect(format!("Failed to create file '{}'", &self.file_path).as_str());
+            .unwrap_or_else(|_| panic!("Failed to create file '{}'", &self.file_path));
         let mut downloaded: u64 = 0;
         let mut stream = res.bytes_stream();
 
@@ -248,24 +248,20 @@ impl BloodyIndianaJones {
             if let Ok(entries) = entries {
                 let entries = entries.collect::<Vec<_>>();
                 if entries.len() == 1 {
-                    for entry in entries {
-                        if let Ok(entry) = entry {
-                            if entry.path().is_dir() {
-                                debug!(
-                                    "Extracted files are contained in sub-folder. Moving them up"
-                                );
-                                let parent = entry.path();
-                                if let Ok(entries) = read_dir(&parent) {
-                                    for entry in entries {
-                                        if let Ok(entry) = entry {
-                                            let path = entry.path();
-                                            let new_path =
-                                                parent_path.join(path.file_name().unwrap());
-                                            rename(&path, new_path).unwrap();
-                                        }
-                                    }
-                                    remove_dir(parent).ok();
+                    for entry in entries.into_iter().flatten() {
+                        if entry.path().is_dir() {
+                            debug!(
+                                "Extracted files are contained in sub-folder. Moving them up"
+                            );
+                            let parent = entry.path();
+                            if let Ok(entries) = read_dir(&parent) {
+                                for entry in entries.flatten() {
+                                    let path = entry.path();
+                                    let new_path =
+                                        parent_path.join(path.file_name().unwrap());
+                                    rename(&path, new_path).unwrap();
                                 }
+                                remove_dir(parent).ok();
                             }
                         }
                     }

--- a/src/stage4/src/checker.rs
+++ b/src/stage4/src/checker.rs
@@ -3,7 +3,6 @@ use crate::executor::{prep, AppInput, GgMeta};
 use crate::updater;
 use crate::Executor;
 use futures_util::future::join_all;
-use glob;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{debug, info};
 use std::collections::HashMap;
@@ -206,7 +205,7 @@ pub async fn check_or_update_all(
     let update_infos: Vec<UpdateInfo> = join_all(check_tasks)
         .await
         .into_iter()
-        .filter_map(|x| x)
+        .flatten()
         .collect();
 
     m.clear().unwrap();
@@ -226,7 +225,7 @@ pub async fn check_or_update_all(
     for info in &update_infos {
         grouped_tools
             .entry(info.tool_name.clone())
-            .or_insert(Vec::new())
+            .or_default()
             .push(info);
     }
 

--- a/src/stage4/src/cli.rs
+++ b/src/stage4/src/cli.rs
@@ -169,71 +169,69 @@ impl Cli {
                     )
                 }
             }
-        } else {
-            if let Some(first_arg) = self.args.first() {
-                if let Some(alias_commands) = config.resolve_alias_with_and(first_arg) {
-                    if alias_commands.len() > 1 {
-                        return (
-                            vec![ClapCmd {
-                                cmd: format!("__multi_alias__{}", first_arg),
-                                version: None,
-                                distribution: None,
-                                include_tags: HashSet::new(),
-                                exclude_tags: HashSet::new(),
-                                gems: None,
-                            }],
-                            self.args[1..].to_vec(),
-                        );
-                    }
+        } else if let Some(first_arg) = self.args.first() {
+            if let Some(alias_commands) = config.resolve_alias_with_and(first_arg) {
+                if alias_commands.len() > 1 {
+                    return (
+                        vec![ClapCmd {
+                            cmd: format!("__multi_alias__{}", first_arg),
+                            version: None,
+                            distribution: None,
+                            include_tags: HashSet::new(),
+                            exclude_tags: HashSet::new(),
+                            gems: None,
+                        }],
+                        self.args[1..].to_vec(),
+                    );
                 }
-
-                if let Some(alias_args) = config.resolve_alias(first_arg) {
-                    let mut expanded_args = alias_args;
-                    expanded_args.extend_from_slice(&self.args[1..]);
-
-                    let mut depth = 0;
-                    const MAX_DEPTH: usize = 10;
-                    while depth < MAX_DEPTH {
-                        if let Some(first) = expanded_args.first() {
-                            if let Some(nested_alias) = config.resolve_alias(first) {
-                                let rest = expanded_args[1..].to_vec();
-                                expanded_args = nested_alias;
-                                expanded_args.extend(rest);
-                                depth += 1;
-                                continue;
-                            }
-                        }
-                        break;
-                    }
-
-                    let cmds = if let Some(cmd_part) = expanded_args.first() {
-                        parse_command_string(cmd_part, config)
-                    } else {
-                        vec![]
-                    };
-                    let app_args = expanded_args[1..].to_vec();
-                    (cmds, app_args)
-                } else {
-                    let cmds = parse_command_string(first_arg, config);
-                    let app_args = self.args[1..].to_vec();
-
-                    if cmds.len() == 1
-                        && cmds[0].cmd == "run"
-                        && app_args.first().map_or(false, |a| {
-                            a.starts_with("gh/") || get_tool_info(a).is_some()
-                        })
-                    {
-                        let tool = &app_args[0];
-                        let new_cmds = parse_command_string(tool, config);
-                        let new_app_args = app_args[1..].to_vec();
-                        return (new_cmds, new_app_args);
-                    }
-
-                    (cmds, app_args)
-                }
-            } else {
-                (vec![], vec![])
             }
+
+            if let Some(alias_args) = config.resolve_alias(first_arg) {
+                let mut expanded_args = alias_args;
+                expanded_args.extend_from_slice(&self.args[1..]);
+
+                let mut depth = 0;
+                const MAX_DEPTH: usize = 10;
+                while depth < MAX_DEPTH {
+                    if let Some(first) = expanded_args.first() {
+                        if let Some(nested_alias) = config.resolve_alias(first) {
+                            let rest = expanded_args[1..].to_vec();
+                            expanded_args = nested_alias;
+                            expanded_args.extend(rest);
+                            depth += 1;
+                            continue;
+                        }
+                    }
+                    break;
+                }
+
+                let cmds = if let Some(cmd_part) = expanded_args.first() {
+                    parse_command_string(cmd_part, config)
+                } else {
+                    vec![]
+                };
+                let app_args = expanded_args[1..].to_vec();
+                (cmds, app_args)
+            } else {
+                let cmds = parse_command_string(first_arg, config);
+                let app_args = self.args[1..].to_vec();
+
+                if cmds.len() == 1
+                    && cmds[0].cmd == "run"
+                    && app_args.first().is_some_and(|a| {
+                        a.starts_with("gh/") || get_tool_info(a).is_some()
+                    })
+                {
+                    let tool = &app_args[0];
+                    let new_cmds = parse_command_string(tool, config);
+                    let new_app_args = app_args[1..].to_vec();
+                    return (new_cmds, new_app_args);
+                }
+
+                (cmds, app_args)
+            }
+        } else {
+            (vec![], vec![])
         }
     }
 

--- a/src/stage4/src/config.rs
+++ b/src/stage4/src/config.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct GgConfig {
     #[serde(default)]
     pub dependencies: HashMap<String, String>,
@@ -13,14 +14,6 @@ pub struct GgConfig {
     pub aliases: HashMap<String, String>,
 }
 
-impl Default for GgConfig {
-    fn default() -> Self {
-        Self {
-            dependencies: HashMap::new(),
-            aliases: HashMap::new(),
-        }
-    }
-}
 
 impl GgConfig {
     pub fn load() -> Self {

--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -34,13 +34,15 @@ pub struct GgVersion(String);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GgVersionReq(String);
 
+impl std::fmt::Display for GgVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl GgVersion {
     pub fn to_version(&self) -> Version {
         Version::parse(&self.0).unwrap()
-    }
-
-    pub fn to_string(&self) -> String {
-        self.0.clone()
     }
 
     pub fn new(version: &str) -> Option<Self> {
@@ -61,13 +63,15 @@ impl GgVersion {
     }
 }
 
+impl std::fmt::Display for GgVersionReq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl GgVersionReq {
     pub fn to_version_req(&self) -> VersionReq {
         VersionReq::parse(&self.0).unwrap()
-    }
-
-    pub fn to_string(&self) -> String {
-        self.0.clone()
     }
 
     pub fn new(version_req: &str) -> Option<Self> {
@@ -215,7 +219,7 @@ impl dyn Executor {
         None
     }
 
-    pub fn get_url_matches(&self, urls: &Vec<Download>, input: &AppInput) -> Vec<Download> {
+    pub fn get_url_matches(&self, urls: &[Download], input: &AppInput) -> Vec<Download> {
         get_url_matches(urls, input, self)
     }
 }
@@ -293,11 +297,7 @@ fn get_executor_app_path(
     path: &str,
 ) -> Option<AppPath> {
     info!("Trying to find {path}");
-    if let Ok(app_path) = get_app_path(path, input) {
-        Some(app_path)
-    } else {
-        None
-    }
+    get_app_path(path, input).ok()
 }
 
 pub async fn prep(
@@ -312,11 +312,7 @@ pub async fn prep(
     let executor_cmd = &executor.get_executor_cmd();
     let version_req = if let Some(ver) = &executor_cmd.version {
         Some(ver.to_version_req())
-    } else if let Some(ver) = executor.get_version_req() {
-        Some(ver)
-    } else {
-        None
-    };
+    } else { executor.get_version_req() };
     let version_req_str = &version_req
         .as_ref()
         .map(|v| v.to_string())
@@ -411,7 +407,6 @@ pub async fn prep(
     bloody_indiana_jones.cleanup_download();
 
     if let Some(download) = url {
-        let download = download;
         let meta = GgMeta {
             download: download.clone(),
             version_req: GgVersionReq(version_req_str.to_string()),
@@ -456,7 +451,7 @@ fn score_filename_match(filename: &str, tool_name: &str, version_re: &Regex) -> 
 }
 
 fn get_url_matches(
-    urls: &Vec<Download>,
+    urls: &[Download],
     input: &AppInput,
     executor: &dyn Executor,
 ) -> Vec<Download> {
@@ -471,11 +466,9 @@ fn get_url_matches(
                 } else {
                     return false;
                 }
-            } else {
-                if let Some(u_var) = u.variant {
-                    if u_var != Variant::Any {
-                        return false;
-                    }
+            } else if let Some(u_var) = u.variant {
+                if u_var != Variant::Any {
+                    return false;
                 }
             }
 
@@ -532,7 +525,7 @@ fn get_url_matches(
                 "Keeping download: {:?} (OS: {:?}, Arch: {:?}) for target (OS: {:?}, Arch: {:?})",
                 u.download_url, u.os, u.arch, input.target.os, input.target.arch
             );
-            return true;
+            true
         })
         .collect::<Vec<_>>();
 
@@ -545,13 +538,13 @@ fn get_url_matches(
         let a_filename = a
             .download_url
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("")
             .to_lowercase();
         let b_filename = b
             .download_url
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("")
             .to_lowercase();
 
@@ -587,7 +580,7 @@ fn get_url_matches(
         }
     });
 
-    urls_match.into_iter().map(|d| d.clone()).collect()
+    urls_match.into_iter().cloned().collect()
 }
 
 fn get_app_path(path: &str, _input: &AppInput) -> Result<AppPath, String> {
@@ -611,19 +604,19 @@ pub async fn try_run(
     path_vars: Vec<String>,
     env_vars: HashMap<String, String>,
 ) -> Result<bool, String> {
-    let args = executor.customize_args(&input, &app_path);
+    let args = executor.customize_args(input, &app_path);
     let path_string = &env::var("PATH").unwrap_or("".to_string());
     let paths = env::join_paths(path_vars.clone())
         .unwrap()
         .to_str()
         .unwrap()
         .to_string();
-    let all_paths = vec![paths, path_string.to_string()].join(match env::consts::OS {
+    let all_paths = [paths, path_string.to_string()].join(match env::consts::OS {
         "windows" => ";",
         _ => ":",
     });
     info!("PATH: {all_paths}");
-    let bins = executor.get_bins(&input);
+    let bins = executor.get_bins(input);
     info!("Trying to find these bins: {:?}", bins);
     for bin in bins {
         let bin_path = match bin {

--- a/src/stage4/src/executors/bld.rs
+++ b/src/stage4/src/executors/bld.rs
@@ -63,7 +63,7 @@ impl Bld {
                         if let Some(class_name) = find_java_files(&path, &new_package) {
                             return Some(class_name);
                         }
-                    } else if path.extension().map_or(false, |ext| ext == "java") {
+                    } else if path.extension().is_some_and(|ext| ext == "java") {
                         let file_name = path.file_stem()?.to_str()?;
                         if file_name.ends_with("Build") {
                             return Some(if package_prefix.is_empty() {

--- a/src/stage4/src/executors/github.rs
+++ b/src/stage4/src/executors/github.rs
@@ -206,11 +206,8 @@ impl Executor for GitHub {
             BinPattern::Exact(base_name.to_lowercase()),
         ];
 
-        match &input.target.os {
-            Windows => {
-                patterns.push(BinPattern::Regex(r".*\.exe$".to_string()));
-            }
-            _ => {}
+        if input.target.os == Windows {
+            patterns.push(BinPattern::Regex(r".*\.exe$".to_string()));
         }
 
         patterns.push(BinPattern::Regex(r"^[^.]*$".to_string()));

--- a/src/stage4/src/executors/go.rs
+++ b/src/stage4/src/executors/go.rs
@@ -16,7 +16,7 @@ fn link_href_to_download(href: &str) -> Option<Download> {
     let href_part = href.replace("/dl/go", "");
     let supported_oses = vec![("linux", Linux), ("darwin", Mac), ("windows", Windows)];
     let supported_archs = vec![("amd64", X86_64), ("arm64", Arm64)];
-    let supported_extensions = vec!["tar.gz", "zip"];
+    let supported_extensions = ["tar.gz", "zip"];
 
     if !supported_extensions
         .iter()
@@ -77,14 +77,13 @@ impl Executor for Go {
             let document = Html::parse_document(body.as_str());
             let downloads: Vec<Download> = document
                 .select(&Selector::parse("a.download").unwrap())
-                .map(|link| {
-                    return if let Some(href) = link.value().attr("href") {
+                .filter_map(|link| {
+                    if let Some(href) = link.value().attr("href") {
                         link_href_to_download(href)
                     } else {
                         None
-                    };
+                    }
                 })
-                .filter_map(|document| document)
                 .collect();
             downloads
         })

--- a/src/stage4/src/executors/gradle_properties.rs
+++ b/src/stage4/src/executors/gradle_properties.rs
@@ -26,7 +26,7 @@ pub struct GradleAndWrapperProperties {
 fn get_version_from_gradle_url(gradle_url: &str) -> Option<String> {
     if let Ok(r) = Regex::new(r"gradle-(.*)-") {
         let captures: Vec<_> = r.captures_iter(gradle_url).collect();
-        if captures.len() > 0 {
+        if !captures.is_empty() {
             if let Some(cap) = captures[0].get(1) {
                 return Some(cap.as_str().to_string());
             }
@@ -55,7 +55,7 @@ impl GradleAndWrapperProperties {
     }
 
     pub fn get_version_from_distribution_url(&self) -> Option<String> {
-        self.get_distribution_url().map(|url| get_version_from_gradle_url(url.as_str())).flatten()
+        self.get_distribution_url().and_then(|url| get_version_from_gradle_url(url.as_str()))
     }
 
     pub fn get_distribution_url(&self) -> Option<String> {

--- a/src/stage4/src/executors/java.rs
+++ b/src/stage4/src/executors/java.rs
@@ -52,7 +52,7 @@ impl Java {
     fn get_distribution(&self) -> crate::executors::java_distributions::DistributionConfig {
         if let Some(ref dist_name) = self.executor_cmd.distribution {
             JavaDistributions::get_by_name(dist_name)
-                .unwrap_or_else(|| JavaDistributions::get_default())
+                .unwrap_or_else(JavaDistributions::get_default)
         } else {
             JavaDistributions::get_default()
         }

--- a/src/stage4/src/executors/java_distributions.rs
+++ b/src/stage4/src/executors/java_distributions.rs
@@ -8,12 +8,14 @@ use serde::Serialize;
 use crate::executor::{Download, GgVersion};
 use crate::target::{Arch, Os, Target, Variant};
 
+type DistributionHandler = fn(&Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>>;
+
 #[derive(Debug, Clone)]
 pub struct DistributionConfig {
     pub name: &'static str,
     pub short_name: &'static str,
     pub default_tags: Vec<&'static str>,
-    pub handler: fn(&Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>>,
+    pub handler: DistributionHandler,
 }
 
 pub struct JavaDistributions;
@@ -78,7 +80,7 @@ struct AzulBundle {
 }
 
 fn get_azul_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>> {
-    let target = target.clone();
+    let target = *target;
     Box::pin(async move {
         let json = reqwest::get("https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,release_status,abi,arch,bundle_type,cpu_gen,ext,features,hw_bitness,javafx,latest,os,support_term").await.unwrap().text().await.unwrap();
         let bundles: Vec<AzulBundle> =
@@ -192,7 +194,7 @@ struct TemurinVersionData {
 }
 
 fn get_temurin_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>> {
-    let target = target.clone();
+    let target = *target;
     Box::pin(async move {
         let mut downloads = Vec::new();
 
@@ -240,16 +242,15 @@ fn get_temurin_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Dow
                                     _ => false,
                                 };
 
-                                let arch_match = match (&target.arch, binary.architecture.as_str())
-                                {
-                                    (Arch::X86_64, "x64") => true,
-                                    (Arch::X86_64, "x86_64") => true,
-                                    (Arch::Arm64, "aarch64") => true,
-                                    (Arch::Arm64, "arm64") => true,
-                                    (Arch::Armv7, "arm") => true,
-                                    (Arch::Any, _) => true,
-                                    _ => false,
-                                };
+                                let arch_match = matches!(
+                                    (&target.arch, binary.architecture.as_str()),
+                                    (Arch::X86_64, "x64")
+                                        | (Arch::X86_64, "x86_64")
+                                        | (Arch::Arm64, "aarch64")
+                                        | (Arch::Arm64, "arm64")
+                                        | (Arch::Armv7, "arm")
+                                        | (Arch::Any, _)
+                                );
 
                                 if os_match && arch_match {
                                     let mut tags = HashSet::new();
@@ -282,7 +283,7 @@ fn get_temurin_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Dow
                                     let variant = if binary.os == "alpine-linux" {
                                         Some(Variant::Musl)
                                     } else {
-                                        target.variant.clone()
+                                        target.variant
                                     };
 
                                     downloads.push(Download {

--- a/src/stage4/src/executors/node.rs
+++ b/src/stage4/src/executors/node.rs
@@ -17,7 +17,7 @@ type Root = Vec<Root2>;
 
 #[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
-enum LTS {
+enum Lts {
     String(String),
     Bool(bool),
 }
@@ -34,7 +34,7 @@ struct Root2 {
     pub zlib: Option<String>,
     pub openssl: Option<String>,
     pub modules: Option<String>,
-    pub lts: LTS,
+    pub lts: Lts,
     pub security: bool,
 }
 
@@ -55,7 +55,7 @@ fn get_package_version() -> Option<Box<VersionReq>> {
                             .get("node")
                             .unwrap_or(&"".to_string()),
                     )
-                    .unwrap_or(VersionReq::default()),
+                    .unwrap_or_default(),
                 ));
             }
         }
@@ -65,7 +65,7 @@ fn get_package_version() -> Option<Box<VersionReq>> {
         let nvmrc = Regex::new("^v").unwrap().replace(&nvmrc, "");
         let nvmrc = nvmrc.trim();
         info!("Got version {nvmrc} from .nvmrc");
-        if let Ok(ver) = VersionReq::parse(&nvmrc) {
+        if let Ok(ver) = VersionReq::parse(nvmrc) {
             info!("Got parsed version {ver} from .nvmrc");
             return Some(Box::new(ver.clone()));
         }
@@ -79,11 +79,7 @@ impl Executor for Node {
     }
 
     fn get_version_req(&self) -> Option<VersionReq> {
-        if let Some(v) = get_package_version() {
-            Some(*v)
-        } else {
-            None
-        }
+        get_package_version().map(|v| *v)
     }
 
     fn get_download_urls<'a>(
@@ -149,10 +145,7 @@ async fn download_urls(host: &str, target: &Target) -> Vec<Download> {
     root.iter().filter(|r|
         r.files.contains(&file.to_string())
     ).map(|r| {
-        let lts = match r.lts {
-            LTS::String(_) => true,
-            _ => false
-        };
+        let lts = matches!(r.lts, Lts::String(_));
         let file_fix = if file.ends_with("-zip") {
             file.replace("-zip", ".zip")
         } else {
@@ -166,7 +159,7 @@ async fn download_urls(host: &str, target: &Target) -> Vec<Download> {
         };
         let version_string = r.version.as_str();
         let version = GgVersion::new(version_string);
-        return Download {
+        Download {
             download_url: format!("https://{host}/download/release/{version_string}/node-{version_string}-{file_fix}"),
             version,
             tags,
@@ -174,7 +167,7 @@ async fn download_urls(host: &str, target: &Target) -> Vec<Download> {
             arch: Some(Arch::Any),
             os: Some(Os::Any),
             variant: Some(Variant::Any),
-        };
+        }
     }).collect()
 }
 

--- a/src/stage4/src/executors/openapigenerator.rs
+++ b/src/stage4/src/executors/openapigenerator.rs
@@ -47,7 +47,7 @@ impl Executor for OpenAPIGenerator {
     fn customize_args(&self, input: &AppInput, app_path: &AppPath) -> Vec<String> {
         let jar = "openapi-generator-cli.jar";
         if let Some(path) = app_path.install_dir.join(jar).to_str() {
-            let args = vec!["-jar".to_string(), path.to_string()];
+            let args = ["-jar".to_string(), path.to_string()];
             args.iter()
                 .cloned()
                 .chain(input.app_args.iter().cloned())

--- a/src/stage4/src/gem_utils.rs
+++ b/src/stage4/src/gem_utils.rs
@@ -68,10 +68,8 @@ pub fn install_gem_to_cache(
                                     new_content.insert_str(require_pos, env_setup);
                                 } else if let Some(require_pos) = new_content.find("require ") {
                                     new_content.insert_str(require_pos, env_setup);
-                                } else {
-                                    if let Some(newline_pos) = new_content.find('\n') {
-                                        new_content.insert_str(newline_pos + 1, env_setup);
-                                    }
+                                } else if let Some(newline_pos) = new_content.find('\n') {
+                                    new_content.insert_str(newline_pos + 1, env_setup);
                                 }
 
                                 let _ = std::fs::write(&exe_path, new_content);

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -382,7 +382,7 @@ async fn main() -> ExitCode {
     };
     info!("System is {system}{}. {:?}", override_info, &target);
 
-    if cmds.first().is_some() {
+    if !cmds.is_empty() {
         let mut executors = cmds
             .iter()
             .filter_map(|cmd| {
@@ -403,20 +403,20 @@ async fn main() -> ExitCode {
         let mut processed_deps = std::collections::HashSet::new();
         while look_for_deps {
             look_for_deps = false;
-            let mut to_add = Vec::new();
+            let mut to_add: Vec<Box<dyn Executor>> = Vec::new();
             for x in &executors {
                 let deps = x.get_deps(input).await;
                 for dep in deps {
                     if !executors
                         .iter()
-                        .any(|e| &e.get_name().to_string() == &dep.name)
+                        .any(|e| e.get_name() == dep.name)
                         && !to_add
                             .iter()
-                            .any(|e: &Box<dyn Executor>| &e.get_name().to_string() == &dep.name)
+                            .any(|e| e.get_name() == dep.name)
                         && !processed_deps.contains(&dep.name)
                     {
                         if dep.optional {
-                            if let Ok(_) = which::which(&dep.name) {
+                            if which::which(&dep.name).is_ok() {
                                 info!(
                                     "Optional dependency '{}' found in PATH, using system version",
                                     dep.name
@@ -451,7 +451,7 @@ async fn main() -> ExitCode {
             }
         }
 
-        if executors.first().is_some() {
+        if !executors.is_empty() {
             let mut env_vars: HashMap<String, String> = HashMap::new();
             let mut path_vars: Vec<String> = vec![];
 
@@ -466,7 +466,7 @@ async fn main() -> ExitCode {
                     (x, pb)
                 })
                 .map(|(x, pb)| async move {
-                    let app_path = prep(&**x, &input, &pb).await?;
+                    let app_path = prep(&**x, input, &pb).await?;
                     let env = x.get_env(&app_path);
                     let bin_dirs = x.get_bin_dirs();
                     Ok::<_, String>((app_path, env, bin_dirs))

--- a/src/stage4/src/target.rs
+++ b/src/stage4/src/target.rs
@@ -82,7 +82,7 @@ impl Target {
     }
 
     fn detect_arch_from_input(parts: &[&str], _input: &str) -> Arch {
-        match parts.get(0).unwrap_or(&"") {
+        match parts.first().unwrap_or(&"") {
             x if x.contains("x86_64") => Arch::X86_64,
             x if x.contains("arm64") => Arch::Arm64,
             x if x.contains("aarch64") => Arch::Arm64,

--- a/src/stage4/src/updater.rs
+++ b/src/stage4/src/updater.rs
@@ -228,6 +228,5 @@ pub async fn perform_update(ver: &str, force: bool) {
 
     if let Err(e) = move_temp_to_final(&temp_path, &final_path) {
         println!("Final move failed: {}", e);
-        return;
     }
 }


### PR DESCRIPTION
Apply cargo clippy --fix for auto-fixable warnings (needless borrows, expect with format, useless vec, etc.) and manually fix remaining ones: Display trait impls, matches! macro, slice params, type alias, LTS rename.