### PR TITLE
Replace deprecated zip-extract with zip crate

### DIFF
--- a/src/stage4/Cargo.lock
+++ b/src/stage4/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -3022,7 +3022,7 @@ dependencies = [
  "tokio",
  "toml",
  "which",
- "zip-extract",
+ "zip",
 ]
 
 [[package]]
@@ -4125,17 +4125,6 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
-]
-
-[[package]]
-name = "zip-extract"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
-dependencies = [
- "log",
- "thiserror",
- "zip",
 ]
 
 [[package]]

--- a/src/stage4/Cargo.toml
+++ b/src/stage4/Cargo.toml
@@ -12,7 +12,7 @@ scraper = { version = "0.23.1" }
 tar = "0.4.44"
 futures-util = "0.3.25"
 async-compression = { version = "0.4.1", features = ["all"] }
-zip-extract = "0.4.0"
+zip = "4"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.103"
 serde_yaml = "0.9"

--- a/src/stage4/src/bloody_indiana_jones.rs
+++ b/src/stage4/src/bloody_indiana_jones.rs
@@ -186,8 +186,8 @@ impl BloodyIndianaJones {
                 task::spawn_blocking(move || {
                     create_dir_all(&path_string).expect("Unable to create download dir");
                     let target_dir = PathBuf::from(&path_string);
-                    zip_extract::extract(File::open(file_path_string).unwrap(), &target_dir, true)
-                        .unwrap();
+                    let file = File::open(file_path_string).unwrap();
+                    zip::ZipArchive::new(file).unwrap().extract(&target_dir).unwrap();
                 })
                 .await
                 .expect("Unable to unzip");


### PR DESCRIPTION
zip-extract is unmaintained and zip >= 2.4 supports extraction natively via ZipArchive::extract(). Drops one dependency.