### PR TITLE
Print absolute path after successful update

### DIFF
--- a/src/stage4/src/updater.rs
+++ b/src/stage4/src/updater.rs
@@ -228,5 +228,12 @@ pub async fn perform_update(ver: &str, force: bool) {
 
     if let Err(e) = move_temp_to_final(&temp_path, &final_path) {
         println!("Final move failed: {}", e);
+        return;
     }
+
+    let absolute_path = std::path::Path::new(&final_path)
+        .canonicalize()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| final_path.clone());
+    println!("Updated: {}", absolute_path);
 }


### PR DESCRIPTION
Resolves #169 — after gg.cmd update completes, print the full path of the updated file so the user knows exactly which file was updated.