### PR TITLE
Make stage3/stage2 failures diagnosable instead of silent

### DIFF
--- a/src/stage2/stage2.sh
+++ b/src/stage2/stage2.sh
@@ -6,14 +6,24 @@ if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]; then
   exit $?
 fi
 
+stage3_executed=""
 if [ ! -f "$CACHE_DIR/gg-VERVER/stage4" ]; then
   cd "$CACHE_DIR/gg-VERVER" || exit
+  # Glob order matters: aarch64* sorts before x86_64*, so on Apple Silicon the
+  # native binary is tried before the x86_64 one (which Rosetta could also run)
   for stage3 in stage3*; do
     chmod +x "$stage3"
-    if "./$stage3" 2>/dev/null; then
+    "./$stage3" 2>/dev/null
+    stage3_result=$?
+    if [ "$stage3_result" = 0 ]; then
       echo "$stage3" >system
       cd - >/dev/null
       break
+    fi
+    # 126/127 mean the binary could not execute at all (wrong arch/OS).
+    # Anything else means it ran but failed (network, hash mismatch, ...)
+    if [ "$stage3_result" != 126 ] && [ "$stage3_result" != 127 ]; then
+      stage3_executed=1
     fi
   done
 fi
@@ -24,5 +34,9 @@ if [ -f "$CACHE_DIR/gg-VERVER/stage4" ]; then
   exit $?
 fi
 
-echo "Your system is not supported. Please check out https://github.com/eirikb/gg"
+if [ -n "$stage3_executed" ]; then
+  echo "gg failed to download its runtime. Check your network connection (any errors above may have details)."
+else
+  echo "Your system is not supported. Please check out https://github.com/eirikb/gg"
+fi
 exit 1

--- a/src/stage3/main.c
+++ b/src/stage3/main.c
@@ -20,18 +20,34 @@ int main() {
     char path[1000];
     snprintf(path, 1000, "/%s", hash);
 
-    struct sockaddr_in serv_addr;
-    const int sock = socket(AF_INET, SOCK_STREAM, 0);
+    struct addrinfo hints;
+    struct addrinfo *result = NULL;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
 
-    struct hostent *server = gethostbyname(host);
+    if (getaddrinfo(host, "80", &hints, &result) != 0 || result == NULL) {
+        printf("DNS lookup failed for %s\n", host);
+        return 1;
+    }
 
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_port = htons(80);
-    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
+    int sock = -1;
+    for (struct addrinfo *ptr = result; ptr != NULL; ptr = ptr->ai_next) {
+        sock = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
+        if (sock < 0) {
+            continue;
+        }
+        if (connect(sock, ptr->ai_addr, ptr->ai_addrlen) == 0) {
+            break;
+        }
+        close(sock);
+        sock = -1;
+    }
+    freeaddrinfo(result);
 
-    if (connect(sock, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
-        printf("\nConnection Failed \n");
-        return -1;
+    if (sock < 0) {
+        printf("Connection to %s failed\n", host);
+        return 1;
     }
 
     FILE *f = fopen("stage4.tmp", "w");
@@ -53,11 +69,24 @@ int main() {
 
     do {
         const long res = read(sock, buffer, bufferSize);
+        if (res <= 0) {
+            printf("\nDownload interrupted\n");
+            fclose(f);
+            remove("stage4.tmp");
+            return 1;
+        }
         if (dataSize == 0) {
-            const char *cl = strstr(strstr(buffer, "Content-Length"), " ");
+            const char *clHeader = strstr(buffer, "Content-Length");
+            const char *cl = clHeader ? strstr(clHeader, " ") : NULL;
+            const char *end = strstr(buffer, "\r\n\r\n");
+            if (cl == NULL || end == NULL) {
+                printf("Unexpected HTTP response from %s\n", host);
+                fclose(f);
+                remove("stage4.tmp");
+                return 1;
+            }
             char *to = strstr(cl, "\r");
             dataSize = strtol(cl, &to, 10);
-            const char *end = strstr(buffer, "\r\n\r\n");
             messageSize = end - buffer + dataSize + 4;
             totalSize = messageSize;
             fwrite(end + 4, 1, res - (messageSize - dataSize), f);


### PR DESCRIPTION
stage3 (unix):
- Replace unchecked gethostbyname (NULL deref = segfault on DNS failure, IPv4-only) with getaddrinfo and a connect loop, matching main-win.c. Fixes silent crash on IPv6-only or DNS-less networks.
- Guard HTTP response parsing: missing Content-Length or header terminator no longer NULL-derefs; read errors no longer loop on a dead socket. Both now print an error and clean up stage4.tmp.

stage2.sh:
- Distinguish 'no stage3 binary could execute' (exit 126/127, truly unsupported system) from 'stage3 ran but failed' (network, hash mismatch). The latter now reports a download failure instead of the misleading 'Your system is not supported'.
- Document that glob order intentionally tries aarch64 before x86_64 (Apple Silicon picks native over Rosetta).