### PR TITLE
Applet dispatch: a renamed gg.cmd acts as an alias for its own name

### DIFF
--- a/src/stage4/src/cli.rs
+++ b/src/stage4/src/cli.rs
@@ -69,6 +69,23 @@ pub struct Cli {
     pub args: Vec<String>,
 }
 
+/// If gg.cmd has been renamed (e.g. to `postmortemthis.cmd`), the new name
+/// acts as an applet (busybox-style): `postmortemthis.cmd args` behaves as
+/// `gg.cmd postmortemthis args`. The name is resolved like any other command
+/// (tool registry or gg.toml alias).
+pub fn applet_from_cmd_path(path: &str) -> Option<String> {
+    let base = path.rsplit(['/', '\\']).next()?;
+    let name = base
+        .strip_suffix(".cmd")
+        .or_else(|| base.strip_suffix(".CMD"))
+        .unwrap_or(base);
+    if name.is_empty() || name.eq_ignore_ascii_case("gg") {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     #[command(about = "Check for updates for all tools (including gg)")]
@@ -397,6 +414,28 @@ mod tests {
             .map(String::from)
             .collect::<Vec<_>>();
         Cli::try_parse_from(args).unwrap()
+    }
+
+    #[test]
+    fn test_applet_from_cmd_path() {
+        assert_eq!(applet_from_cmd_path("./gg.cmd"), None);
+        assert_eq!(applet_from_cmd_path("/home/x/gg.cmd"), None);
+        assert_eq!(applet_from_cmd_path("C:\\tools\\GG.CMD"), None);
+        assert_eq!(applet_from_cmd_path("gg"), None);
+        assert_eq!(applet_from_cmd_path(""), None);
+        assert_eq!(
+            applet_from_cmd_path("./postmortemthis.cmd"),
+            Some("postmortemthis".to_string())
+        );
+        assert_eq!(
+            applet_from_cmd_path("/a/b/build.cmd"),
+            Some("build".to_string())
+        );
+        assert_eq!(
+            applet_from_cmd_path("C:\\proj\\deploy.cmd"),
+            Some("deploy".to_string())
+        );
+        assert_eq!(applet_from_cmd_path("node"), Some("node".to_string()));
     }
 
     #[test]

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -194,7 +194,15 @@ fn print_tool_info(tool: &tools::ToolInfo) {
 async fn main() -> ExitCode {
     let ver = option_env!("VERSION").unwrap_or("dev");
 
-    let cli = Cli::parse();
+    let mut raw_args: Vec<String> = env::args().collect();
+    if let Some(applet) = env::var("GG_CMD_PATH")
+        .ok()
+        .as_deref()
+        .and_then(cli::applet_from_cmd_path)
+    {
+        raw_args.insert(1, applet);
+    }
+    let cli = Cli::parse_from(&raw_args);
     let log_level = match cli.get_log_level().as_str() {
         "trace" => LevelFilter::Trace,
         "debug" => LevelFilter::Debug,


### PR DESCRIPTION
Busybox-style: if gg.cmd is renamed (e.g. build.cmd), the new name is prepended as the command, so 'build.cmd args' behaves as 'gg.cmd build args'. The name resolves like any other command (tool registry or gg.toml alias), enabling single-file self-bootstrapping launchers named after the tool they provide.

Uses the existing GG_CMD_PATH exported by stage1; plain gg.cmd is unaffected.

Extracted from feature/eirikb/agent-clis.