### PR TITLE
Honor http(s)_proxy env vars in bootstrap downloads (#245)

### DIFF
--- a/src/stage2/stage2.ps1
+++ b/src/stage2/stage2.ps1
@@ -68,9 +68,28 @@ if ($hash)
         Remove-Item $tempFile -Force
     }
 
+    # Invoke-WebRequest only knows the system (WinINET) proxy and ignores the
+    # conventional env vars, which breaks behind proxies configured that way
+    # (e.g. corporate networks pointing https_proxy at an unauthenticated
+    # proxy). Env vars are case-insensitive on Windows, so https_proxy also
+    # matches HTTPS_PROXY.
+    $proxyArgs = @{ }
+    $envProxy = if ($env:https_proxy)
+    {
+        $env:https_proxy
+    }
+    else
+    {
+        $env:all_proxy
+    }
+    if ($envProxy -and $envProxy -match '^https?://')
+    {
+        $proxyArgs = @{ Proxy = $envProxy; ProxyUseDefaultCredentials = $true }
+    }
+
     try
     {
-        Invoke-WebRequest "https://ggcmd.z13.web.core.windows.net/$hash" -OutFile $tempFile
+        Invoke-WebRequest "https://ggcmd.z13.web.core.windows.net/$hash" -OutFile $tempFile @proxyArgs
         if ((Test-Path $tempFile) -and ((Get-Item $tempFile).Length -gt 0))
         {
             Move-Item $tempFile $stage4 -Force

--- a/src/stage3/main.c
+++ b/src/stage3/main.c
@@ -13,6 +13,57 @@
  * Using HTTP, not HTTPS. Hard coded checksum.
  **/
 
+/* Honor http_proxy / all_proxy (the download is plain HTTP). Accepts
+ * [http://]host[:port]; other schemes (socks, https) are ignored and we
+ * connect directly. Credentials are not supported (no base64 here) and are
+ * stripped, so an authenticating proxy will answer 407. */
+static int parseProxy(char *host, size_t hostSize, char *port, size_t portSize) {
+    const char *vars[] = {"http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"};
+    const char *v = NULL;
+    for (size_t i = 0; i < sizeof(vars) / sizeof(vars[0]) && v == NULL; i++) {
+        v = getenv(vars[i]);
+        if (v != NULL && *v == '\0') {
+            v = NULL;
+        }
+    }
+    if (v == NULL) {
+        return 0;
+    }
+    const char *p = strstr(v, "://");
+    if (p != NULL) {
+        if (strncmp(v, "http://", 7) != 0) {
+            return 0;
+        }
+        p += 3;
+    } else {
+        p = v;
+    }
+    const char *at = strchr(p, '@');
+    if (at != NULL) {
+        printf("Proxy credentials are not supported, trying without\n");
+        p = at + 1;
+    }
+    size_t hostLen = strcspn(p, ":/");
+    if (hostLen == 0 || hostLen >= hostSize) {
+        return 0;
+    }
+    memcpy(host, p, hostLen);
+    host[hostLen] = '\0';
+    p += hostLen;
+    if (*p == ':') {
+        p++;
+        size_t portLen = strcspn(p, "/");
+        if (portLen == 0 || portLen >= portSize) {
+            return 0;
+        }
+        memcpy(port, p, portLen);
+        port[portLen] = '\0';
+    } else {
+        snprintf(port, portSize, "80");
+    }
+    return 1;
+}
+
 int main() {
     const long bufferSize = 65536;
     const char *host = "ggcmd.z13.web.core.windows.net";
@@ -20,14 +71,20 @@ int main() {
     char path[1000];
     snprintf(path, 1000, "/%s", hash);
 
+    char proxyHost[256];
+    char proxyPort[16];
+    const int useProxy = parseProxy(proxyHost, sizeof(proxyHost), proxyPort, sizeof(proxyPort));
+    const char *connectHost = useProxy ? proxyHost : host;
+    const char *connectPort = useProxy ? proxyPort : "80";
+
     struct addrinfo hints;
     struct addrinfo *result = NULL;
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    if (getaddrinfo(host, "80", &hints, &result) != 0 || result == NULL) {
-        printf("DNS lookup failed for %s\n", host);
+    if (getaddrinfo(connectHost, connectPort, &hints, &result) != 0 || result == NULL) {
+        printf("DNS lookup failed for %s\n", connectHost);
         return 1;
     }
 
@@ -46,7 +103,7 @@ int main() {
     freeaddrinfo(result);
 
     if (sock < 0) {
-        printf("Connection to %s failed\n", host);
+        printf("Connection to %s failed\n", connectHost);
         return 1;
     }
 
@@ -56,9 +113,15 @@ int main() {
         exit(1);
     }
 
-    char header[1024];
-    snprintf(header, sizeof(header), "GET %s HTTP/1.1\r\nHost: %s\r\n\r\n", path,
-             host);
+    char header[1200];
+    if (useProxy) {
+        // Through a proxy the request line must carry the absolute URI
+        snprintf(header, sizeof(header),
+                 "GET http://%s%s HTTP/1.1\r\nHost: %s\r\n\r\n", host, path, host);
+    } else {
+        snprintf(header, sizeof(header), "GET %s HTTP/1.1\r\nHost: %s\r\n\r\n",
+                 path, host);
+    }
     send(sock, header, strlen(header), 0);
 
     char buffer[bufferSize];
@@ -68,7 +131,7 @@ int main() {
     int p = 0;
 
     do {
-        const long res = read(sock, buffer, bufferSize);
+        const long res = read(sock, buffer, bufferSize - 1);
         if (res <= 0) {
             printf("\nDownload interrupted\n");
             fclose(f);
@@ -76,6 +139,15 @@ int main() {
             return 1;
         }
         if (dataSize == 0) {
+            buffer[res] = '\0';
+            const char *statusSpace = strncmp(buffer, "HTTP/", 5) == 0 ? strchr(buffer, ' ') : NULL;
+            const int status = statusSpace ? atoi(statusSpace + 1) : 0;
+            if (status != 200) {
+                printf("HTTP error %d from %s\n", status, connectHost);
+                fclose(f);
+                remove("stage4.tmp");
+                return 1;
+            }
             const char *clHeader = strstr(buffer, "Content-Length");
             const char *cl = clHeader ? strstr(clHeader, " ") : NULL;
             const char *end = strstr(buffer, "\r\n\r\n");


### PR DESCRIPTION
The stage4 binary (reqwest) already reads the conventional proxy env vars, but both bootstrap downloaders ignored them:

- stage2.ps1 (Windows): Invoke-WebRequest only knows the system WinINET proxy, so pointing https_proxy at an alternative (e.g. unauthenticated corporate) proxy had no effect, and downloads died with errors like "Proxy Authorization Required". Now passes -Proxy plus -ProxyUseDefaultCredentials when https_proxy/all_proxy is set to an http(s) URL.

- stage3 (Linux/macOS C): always connected directly to the blob host on port 80. Now parses http_proxy/HTTP_PROXY/all_proxy/ALL_PROXY ([http://]host[:port]), connects through the proxy and sends an absolute-URI GET. Non-http schemes (socks) are ignored; credentials are stripped with a notice (no base64 in stage3).

Also check the HTTP status line in stage3: previously a 404/407/502 response body was downloaded and only failed later with a confusing "Hash did not match"; now it fails immediately with "HTTP error NNN". The first read is NUL-terminated before the strstr header parsing, which was relying on luck before.

Tested end-to-end against the live blob store with a real release hash: direct, via a local forwarding proxy (absolute-URI request verified), creds-stripping, socks ignored, unreachable proxy, and 404 on both paths. stage2.ps1 logic verified with pwsh.