### PR TITLE
Feature/eirikb/agent cli tools (#262)

### DIFF
--- a/src/stage4/src/bloody_indiana_jones.rs
+++ b/src/stage4/src/bloody_indiana_jones.rs
@@ -160,7 +160,9 @@ impl BloodyIndianaJones {
         self.pb.set_message("Extracting");
 
         info!("Extracting {}", self.file_name);
-        let ext = Path::new(&self.file_name).extension().unwrap().to_str();
+        let ext = Path::new(&self.file_name)
+            .extension()
+            .and_then(|e| e.to_str());
         let file_buf_reader =
             tokio::io::BufReader::new(tokio::fs::File::open(&self.file_path).await.unwrap());
         let file_path_decomp = if ext == Some("tgz") {

--- a/src/stage4/src/executors/claude.rs
+++ b/src/stage4/src/executors/claude.rs
@@ -1,0 +1,129 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use log::{debug, info};
+
+use crate::executor::{AppInput, BinPattern, Download, Executor, ExecutorCmd, GgVersion};
+use crate::target::{Arch, Os, Variant};
+
+const DOWNLOAD_BASE_URL: &str = "https://downloads.claude.ai/claude-code-releases";
+
+/// Claude Code - distributed via Anthropic's native installer endpoints
+/// (npm is deprecated). Version resolution: `<base>/latest` returns the
+/// latest version string; the binary lives at `<base>/<version>/<platform>/claude`.
+pub struct Claude {
+    pub executor_cmd: ExecutorCmd,
+}
+
+fn platform_string(target: &crate::target::Target) -> Option<String> {
+    let arch = match target.arch {
+        Arch::X86_64 => "x64",
+        Arch::Arm64 => "arm64",
+        _ => return None,
+    };
+    Some(match target.os {
+        Os::Linux => match target.variant {
+            Some(Variant::Musl) => format!("linux-{arch}-musl"),
+            _ => format!("linux-{arch}"),
+        },
+        Os::Mac => format!("darwin-{arch}"),
+        Os::Windows => {
+            if arch != "x64" {
+                return None;
+            }
+            "win32-x64".to_string()
+        }
+        _ => return None,
+    })
+}
+
+async fn get_claude_downloads(target: &crate::target::Target) -> Vec<Download> {
+    let Some(platform) = platform_string(target) else {
+        debug!("claude: unsupported platform");
+        return vec![];
+    };
+
+    let version = match reqwest::get(format!("{DOWNLOAD_BASE_URL}/latest")).await {
+        Ok(res) => match res.text().await {
+            Ok(text) => text.trim().to_string(),
+            Err(e) => {
+                info!("claude: failed to read latest version: {e}");
+                return vec![];
+            }
+        },
+        Err(e) => {
+            info!("claude: failed to fetch latest version: {e}");
+            return vec![];
+        }
+    };
+
+    if !version
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        info!("claude: unexpected version response: {version}");
+        return vec![];
+    }
+
+    let binary = if target.os == Os::Windows {
+        "claude.exe"
+    } else {
+        "claude"
+    };
+
+    vec![Download {
+        download_url: format!("{DOWNLOAD_BASE_URL}/{version}/{platform}/{binary}"),
+        version: GgVersion::new(&version),
+        os: Some(Os::Any),
+        arch: Some(Arch::Any),
+        variant: Some(Variant::Any),
+        tags: Default::default(),
+    }]
+}
+
+impl Executor for Claude {
+    fn get_executor_cmd(&self) -> &ExecutorCmd {
+        &self.executor_cmd
+    }
+
+    fn get_download_urls<'a>(
+        &self,
+        input: &'a AppInput,
+    ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
+        Box::pin(async move { get_claude_downloads(&input.target).await })
+    }
+
+    fn get_bins(&self, input: &AppInput) -> Vec<BinPattern> {
+        vec![BinPattern::Exact(
+            match &input.target.os {
+                Os::Windows => "claude.exe",
+                _ => "claude",
+            }
+            .to_string(),
+        )]
+    }
+
+    fn get_name(&self) -> &str {
+        "claude"
+    }
+
+    fn get_bin_dirs(&self) -> Vec<String> {
+        vec![".".to_string()]
+    }
+
+    fn post_prep(&self, cache_path: &str) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let bin = std::path::Path::new(cache_path).join("claude");
+            if bin.exists() {
+                let perms = std::fs::Permissions::from_mode(0o755);
+                if let Err(e) = std::fs::set_permissions(&bin, perms) {
+                    println!("claude: failed to set executable permission: {e}");
+                }
+            }
+        }
+    }
+}

--- a/src/stage4/src/executors/github.rs
+++ b/src/stage4/src/executors/github.rs
@@ -17,6 +17,7 @@ pub struct GitHub {
     pub repo: String,
     pub predefined_deps: Option<Vec<ExecutorDep>>,
     pub predefined_bins: Option<Vec<String>>,
+    pub excluded_asset_keywords: Vec<String>,
 }
 
 impl GitHub {
@@ -27,6 +28,7 @@ impl GitHub {
             repo,
             predefined_deps: None,
             predefined_bins: None,
+            excluded_asset_keywords: vec![],
         }
     }
 
@@ -43,7 +45,23 @@ impl GitHub {
             repo,
             predefined_deps,
             predefined_bins,
+            excluded_asset_keywords: vec![],
         }
+    }
+
+    /// Skip assets whose name contains any of these keywords. For repos that
+    /// publish several same-platform variants per release (kimi-cli's
+    /// `-onedir` bundles, mistral-vibe's `vibe-acp-*` editor-protocol
+    /// builds), the os+arch+version sort ties and selection becomes
+    /// arbitrary; excluding the unwanted variants keeps it deterministic.
+    pub fn with_excluded_asset_keywords(mut self, keywords: Vec<&str>) -> Self {
+        self.excluded_asset_keywords = keywords.into_iter().map(|k| k.to_lowercase()).collect();
+        self
+    }
+
+    fn is_excluded_asset(name: &str, excluded_keywords: &[String]) -> bool {
+        let name_lower = name.to_lowercase();
+        excluded_keywords.iter().any(|k| name_lower.contains(k))
     }
 
     async fn detect_language_and_deps(&self) -> Vec<ExecutorDep> {
@@ -157,6 +175,7 @@ impl Executor for GitHub {
     ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
         let owner = self.owner.clone();
         let repo = self.repo.clone();
+        let excluded_keywords = self.excluded_asset_keywords.clone();
 
         Box::pin(async move {
             let mut downloads: Vec<Download> = vec![];
@@ -178,6 +197,11 @@ impl Executor for GitHub {
                     for release in releases.items {
                         for asset in release.assets {
                             if !Self::is_likely_binary(&asset.name) {
+                                continue;
+                            }
+
+                            if Self::is_excluded_asset(&asset.name, &excluded_keywords) {
+                                debug!("Skipping excluded asset: {}", asset.name);
                                 continue;
                             }
 
@@ -344,6 +368,39 @@ mod tests {
         assert!(!GitHub::is_likely_binary("SHA256SUMS"));
         assert!(!GitHub::is_likely_binary("tool.asc"));
         assert!(!GitHub::is_likely_binary("CHANGELOG.md"));
+    }
+
+    #[test]
+    fn test_is_excluded_asset() {
+        // kimi-cli ships a single-binary and an -onedir bundle per platform
+        let excluded = vec!["onedir".to_string()];
+        assert!(GitHub::is_excluded_asset(
+            "kimi-1.47.0-x86_64-unknown-linux-gnu-onedir.tar.gz",
+            &excluded
+        ));
+        assert!(!GitHub::is_excluded_asset(
+            "kimi-1.47.0-x86_64-unknown-linux-gnu.tar.gz",
+            &excluded
+        ));
+
+        // mistral-vibe ships vibe-acp-* (editor protocol) next to vibe-*
+        let excluded = vec!["vibe-acp".to_string()];
+        assert!(GitHub::is_excluded_asset(
+            "vibe-acp-linux-x86_64-2.14.1.zip",
+            &excluded
+        ));
+        assert!(!GitHub::is_excluded_asset(
+            "vibe-linux-x86_64-2.14.1.zip",
+            &excluded
+        ));
+
+        // matching is case-insensitive on the asset name
+        assert!(GitHub::is_excluded_asset(
+            "Tool-Linux-OneDir.tar.gz",
+            &["onedir".to_string()]
+        ));
+
+        assert!(!GitHub::is_excluded_asset("anything.tar.gz", &[]));
     }
 
     #[test]

--- a/src/stage4/src/executors/mod.rs
+++ b/src/stage4/src/executors/mod.rs
@@ -1,4 +1,5 @@
 pub mod bld;
+pub mod claude;
 pub mod custom_command;
 pub mod flutter;
 pub mod github;

--- a/src/stage4/src/executors/node.rs
+++ b/src/stage4/src/executors/node.rs
@@ -40,6 +40,20 @@ struct Root2 {
 
 pub struct Node {
     pub executor_cmd: ExecutorCmd,
+    pub npm_package: Option<NpmPackageSpec>,
+}
+
+/// A tool distributed as an npm package, executed on a gg-managed Node.js.
+/// Gets its own cache dir (named `name`), with the package installed into
+/// `npm_home/` by `post_prep` (mirrors the Ruby gems pattern).
+#[derive(Clone)]
+pub struct NpmPackageSpec {
+    /// Tool name (cache dir name), e.g. "gemini-cli"
+    pub name: String,
+    /// npm package, e.g. "@google/gemini-cli"
+    pub package: String,
+    /// Executable name the package installs, e.g. "gemini"
+    pub bin: String,
 }
 
 fn get_package_version() -> Option<Box<VersionReq>> {
@@ -90,6 +104,15 @@ impl Executor for Node {
     }
 
     fn get_bins(&self, input: &AppInput) -> Vec<BinPattern> {
+        if let Some(spec) = &self.npm_package {
+            return match &input.target.os {
+                Os::Windows => vec![
+                    BinPattern::Exact(format!("npm_home/{}.cmd", spec.bin)),
+                    BinPattern::Exact(format!("npm_home/{}", spec.bin)),
+                ],
+                _ => vec![BinPattern::Exact(format!("npm_home/bin/{}", spec.bin))],
+            };
+        }
         vec![BinPattern::Exact(
             match &input.target.os {
                 Os::Windows => match self.executor_cmd.cmd.as_str() {
@@ -108,7 +131,73 @@ impl Executor for Node {
     }
 
     fn get_name(&self) -> &str {
-        "node"
+        match &self.npm_package {
+            Some(spec) => &spec.name,
+            None => "node",
+        }
+    }
+
+    fn get_bin_dirs(&self) -> Vec<String> {
+        if self.npm_package.is_some() {
+            // node itself + npm-installed bins (unix: npm_home/bin, windows: npm_home)
+            vec![
+                "bin".to_string(),
+                ".".to_string(),
+                "npm_home/bin".to_string(),
+                "npm_home".to_string(),
+            ]
+        } else {
+            vec!["bin".to_string(), ".".to_string()]
+        }
+    }
+
+    fn post_prep(&self, cache_path: &str) {
+        let Some(spec) = &self.npm_package else {
+            return;
+        };
+        let cache = std::path::Path::new(cache_path);
+        let npm_home = cache.join("npm_home");
+        let _ = fs::create_dir_all(&npm_home);
+        // Keep npm's own download cache (~/.npm) and node-gyp's header cache
+        // (~/.cache/node-gyp) inside gg's cache dir, so install is fully
+        // self-contained.
+        let npm_cache = cache.join("npm_cache");
+        let node_gyp_dir = cache.join("node_gyp");
+
+        let (npm, node_bin_dir) = if cfg!(windows) {
+            (cache.join("npm.cmd"), cache.to_path_buf())
+        } else {
+            (cache.join("bin").join("npm"), cache.join("bin"))
+        };
+
+        let path_sep = if cfg!(windows) { ";" } else { ":" };
+        let path_env = format!(
+            "{}{}{}",
+            node_bin_dir.display(),
+            path_sep,
+            std::env::var("PATH").unwrap_or_default()
+        );
+
+        info!(
+            "Installing npm package {} into {:?}",
+            spec.package, npm_home
+        );
+        let status = std::process::Command::new(&npm)
+            .arg("install")
+            .arg("-g")
+            .arg("--prefix")
+            .arg(&npm_home)
+            .arg(&spec.package)
+            .env("PATH", path_env)
+            .env("npm_config_cache", &npm_cache)
+            .env("npm_config_devdir", &node_gyp_dir)
+            .status();
+
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => println!("npm install {} failed: {}", spec.package, s),
+            Err(e) => println!("npm install {} failed: {}", spec.package, e),
+        }
     }
 }
 

--- a/src/stage4/src/tools.rs
+++ b/src/stage4/src/tools.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use crate::executor::{Executor, ExecutorCmd, ExecutorDep};
 use crate::executors::bld::Bld;
+use crate::executors::claude::Claude;
 use crate::executors::custom_command::CustomCommand;
 use crate::executors::flutter::Flutter;
 use crate::executors::github::GitHub;
@@ -11,7 +12,7 @@ use crate::executors::gradle::Gradle;
 use crate::executors::java::Java;
 use crate::executors::jbang::JBangExecutor;
 use crate::executors::maven::Maven;
-use crate::executors::node::Node;
+use crate::executors::node::{Node, NpmPackageSpec};
 use crate::executors::openapigenerator::OpenAPIGenerator;
 use crate::executors::rat::Rat;
 use crate::executors::ruby::Ruby;
@@ -44,7 +45,12 @@ pub static TOOL_REGISTRY: LazyLock<HashMap<&'static str, ToolInfo>> = LazyLock::
             category: ToolCategory::Language,
             tags: vec!["+lts"],
             example: Some("gg node@14 -e 'console.log(1)'"),
-            factory: |cmd| Some(Box::new(Node { executor_cmd: cmd })),
+            factory: |cmd| {
+                Some(Box::new(Node {
+                    executor_cmd: cmd,
+                    npm_package: None,
+                }))
+            },
         },
         ToolInfo {
             name: "java",
@@ -257,6 +263,113 @@ pub static TOOL_REGISTRY: LazyLock<HashMap<&'static str, ToolInfo>> = LazyLock::
                 // transitively via googleauth, but googleauth 1.17.0 dropped it.
                 ruby_cmd.gems = Some(vec!["fastlane".to_string(), "multi_json".to_string()]);
                 Some(Box::new(Ruby { executor_cmd: ruby_cmd }))
+            },
+        },
+        ToolInfo {
+            name: "claude",
+            aliases: vec!["claude-code"],
+            description: "Claude Code - Anthropic's coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg claude --version"),
+            factory: |cmd| Some(Box::new(Claude { executor_cmd: cmd })),
+        },
+        ToolInfo {
+            name: "gemini-cli",
+            aliases: vec!["gemini"],
+            description: "Google Gemini CLI - coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg gemini-cli --version"),
+            factory: |cmd| {
+                Some(Box::new(Node {
+                    executor_cmd: cmd,
+                    npm_package: Some(NpmPackageSpec {
+                        name: "gemini-cli".to_string(),
+                        package: "@google/gemini-cli".to_string(),
+                        bin: "gemini".to_string(),
+                    }),
+                }))
+            },
+        },
+        ToolInfo {
+            name: "codex",
+            aliases: vec![],
+            description: "OpenAI Codex CLI - coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg codex --version"),
+            // npm, not GitHub releases: the release page mixes in alpha
+            // prereleases and many same-prefixed assets (codex-app-server,
+            // bundles, .zst); @openai/codex resolves the right stable native
+            // binary per platform via optionalDependencies.
+            factory: |cmd| {
+                Some(Box::new(Node {
+                    executor_cmd: cmd,
+                    npm_package: Some(NpmPackageSpec {
+                        name: "codex".to_string(),
+                        package: "@openai/codex".to_string(),
+                        bin: "codex".to_string(),
+                    }),
+                }))
+            },
+        },
+        ToolInfo {
+            name: "qwen",
+            aliases: vec!["qwen-code"],
+            description: "Qwen Code - Alibaba's coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg qwen --version"),
+            factory: |cmd| {
+                Some(Box::new(Node {
+                    executor_cmd: cmd,
+                    npm_package: Some(NpmPackageSpec {
+                        name: "qwen".to_string(),
+                        package: "@qwen-code/qwen-code".to_string(),
+                        bin: "qwen".to_string(),
+                    }),
+                }))
+            },
+        },
+        ToolInfo {
+            name: "kimi",
+            aliases: vec!["kimi-cli"],
+            description: "Kimi CLI - Moonshot AI's coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg kimi --version"),
+            factory: |cmd| {
+                Some(Box::new(
+                    GitHub::new_with_config(
+                        cmd,
+                        "MoonshotAI".to_string(),
+                        "kimi-cli".to_string(),
+                        Some(vec![]),
+                        Some(vec!["kimi".to_string(), "kimi.exe".to_string()]),
+                    )
+                    .with_excluded_asset_keywords(vec!["onedir"]),
+                ))
+            },
+        },
+        ToolInfo {
+            name: "vibe",
+            aliases: vec!["mistral-vibe"],
+            description: "Mistral Vibe - Mistral's coding agent for your terminal",
+            category: ToolCategory::Utility,
+            tags: vec![],
+            example: Some("gg vibe --version"),
+            factory: |cmd| {
+                Some(Box::new(
+                    GitHub::new_with_config(
+                        cmd,
+                        "mistralai".to_string(),
+                        "mistral-vibe".to_string(),
+                        Some(vec![]),
+                        Some(vec!["vibe".to_string(), "vibe.exe".to_string()]),
+                    )
+                    .with_excluded_asset_keywords(vec!["vibe-acp"]),
+                ))
             },
         },
         ToolInfo {


### PR DESCRIPTION
* Add agent CLI tools: claude, codex, gemini-cli

Three coding-agent CLIs from the major labs, all contained in gg's cache (no system-wide installers):

- claude (Anthropic): native binary from downloads.claude.ai, no installer. Requires the extension-less-filename fix in bloody_indiana_jones (the asset is a raw binary named 'claude' with no extension, which the old .extension().unwrap() panicked on).
- gemini-cli (Google): npm @google/gemini-cli on a gg-managed Node, via a new NpmPackageSpec pattern (mirrors the Ruby gems approach) that installs into npm_home/ in the tool's own cache dir.
- codex (OpenAI): npm @openai/codex. NOT GitHub releases -- that page mixes alpha prereleases with many same-prefixed assets (codex-app-server, bundles, .zst), and gg's selector picked codex-app-server-package alpha and then silently fell through to a system /usr/bin/codex. The npm package resolves the right stable native binary per platform via optionalDependencies.

npm installs are kept fully self-contained: npm_config_cache and npm_config_devdir are pointed inside the tool's cache dir so nothing leaks to ~/.npm or ~/.cache/node-gyp.

Verified end-to-end in an isolated cache+HOME: all three download, install into .cache/gg, and run the cached binary (claude 2.1.168, codex-cli 0.137.0, gemini 0.45.2) with no install-time pollution of HOME.

Extracted from feature/eirikb/agent-clis.

* Add more agent CLI tools: qwen, kimi, vibe

The remaining first-party lab CLIs (by the lab, for their own models):

- qwen (Alibaba): npm @qwen-code/qwen-code on a gg-managed Node, same NpmPackageSpec pattern as gemini-cli/codex.
- kimi (Moonshot AI): native per-platform binaries from MoonshotAI/kimi-cli GitHub releases.
- vibe (Mistral, powered by Devstral): native per-platform binaries from mistralai/mistral-vibe GitHub releases.

kimi and vibe both publish several same-platform assets per release (kimi's -onedir bundles, vibe's vibe-acp-* editor-protocol builds), so the os+arch+version sort ties and selection becomes arbitrary -- the same prefix-collision problem codex had on GitHub releases. New excluded_asset_keywords on the GitHub executor filters these out at download-listing time, keeping selection deterministic.

xAI, DeepSeek and Z.ai have no official CLIs (community tools only), so this completes the set for now.

Verified end-to-end in an isolated cache+HOME: all three download, install into .cache/gg, and run the cached binary (kimi 1.47.0, vibe 2.14.1, qwen 0.17.1). Aliases qwen-code/kimi-cli/mistral-vibe also dispatch correctly.