### PR TITLE
CI: pull container images from ECR Public mirror instead of Docker Hub

### DIFF
--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -441,12 +441,16 @@ jobs:
   test-container:
     needs: [ stage1, hash ]
     strategy:
+      # One flaky image pull should not cancel the rest of the matrix
+      fail-fast: false
       matrix:
         container: [ ubuntu, debian, alpine, archlinux ]
         cmd: [ "node@14 -v", "java -version", "gradle -version", "openapi version", "run:java@14 java -version", "run:java@21-azul java -version", "run:java@21-tem java -version", "run:java@17-tem java -version", "just -V", "fortio version", "gh/mozilla/sccache -V" ]
 
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    # Docker Hub rate-limits anonymous pulls from shared GitHub runner IPs,
+    # so pull the same official images from AWS's public mirror instead
+    container: public.ecr.aws/docker/library/${{ matrix.container }}:latest
     steps:
       - name: Download gg
         uses: actions/download-artifact@v8


### PR DESCRIPTION
Docker Hub rate-limits anonymous pulls from shared GitHub runner IPs, which made test-container jobs fail in 'Initialize containers' before any test ran (and fail-fast then cancelled innocent sibling jobs). The same official images are served by public.ecr.aws/docker/library without those limits. Also set fail-fast: false so one transient pull failure only needs a re-run of that single job.