### PR TITLE
add postmortem tool: run every AI coding CLI on your diff

### DIFF
--- a/src/stage4/src/tools.rs
+++ b/src/stage4/src/tools.rs
@@ -389,6 +389,25 @@ pub static TOOL_REGISTRY: LazyLock<HashMap<&'static str, ToolInfo>> = LazyLock::
                 ))
             },
         },
+        ToolInfo {
+            name: "postmortem",
+            // Applet alias: postmortemthis.cmd dispatches to this tool, so
+            // `sh postmortemthis.cmd skill` runs `postmortem skill`.
+            aliases: vec!["postmortemthis"],
+            description: "postmortem - run every AI coding CLI you have on your diff, read-only",
+            category: ToolCategory::GitHubRelease,
+            tags: vec![],
+            example: Some("gg postmortem doctor"),
+            factory: |cmd| {
+                Some(create_github_executor(
+                    cmd,
+                    "Softeria",
+                    "postmortemthis",
+                    vec![],
+                    vec!["postmortem", "postmortem.exe"],
+                ))
+            },
+        },
     ];
 
     let mut registry = HashMap::new();


### PR DESCRIPTION
Registers a GitHub-release tool fetching Softeria/postmortemthis, with a postmortemthis alias so the postmortemthis.cmd applet dispatches to it.