### PR TITLE
fix plain .tar extraction: untar the original file directly

### DIFF
--- a/src/stage4/src/bloody_indiana_jones.rs
+++ b/src/stage4/src/bloody_indiana_jones.rs
@@ -244,7 +244,20 @@ impl BloodyIndianaJones {
                 .await
                 .expect("Unable to extract 7z");
             }
-            Some("tar") => (),
+            Some("tar") => {
+                // A directly-downloaded plain .tar needs no decompression, but it
+                // still has to be unpacked. The shared untar step further down keys
+                // off file_path_decomp ending in ".tar" - but for a plain tar that
+                // name has already had its extension stripped (and version dots make
+                // it worse: jbang-0.139.3-linux-x64.tar -> "...-x64", ext "3-linux-x64"),
+                // so that step never fires. Untar the original file here instead.
+                info!("Untar {}", &self.file_path);
+                self.pb.set_message("Untar");
+                create_dir_all(&self.path).expect("Unable to create download dir");
+                let mut archive =
+                    tar::Archive::new(std::io::BufReader::new(File::open(&self.file_path).unwrap()));
+                archive.unpack(&self.path).expect("Unable to extract");
+            }
             Some("gem") => {
                 info!("Processing gem file");
                 self.pb.set_message("Installing gem");
@@ -388,6 +401,51 @@ mod tests {
         assert!(install_dir.join("bin").join("java").exists());
         assert!(install_dir.join("lib").join("jvm.cfg").exists());
         assert!(!install_dir.join("Contents").exists());
+    }
+
+    async fn make_tar(file_path: &str, entries: &[&str]) {
+        let mut builder = tar::Builder::new(Vec::new());
+        for entry in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, entry, std::io::empty())
+                .unwrap();
+        }
+        let tar_bytes = builder.into_inner().unwrap();
+        tokio::fs::write(file_path, tar_bytes).await.unwrap();
+    }
+
+    async fn unpack_url(url: &str, entries: &[&str]) -> tempfile::TempDir {
+        let target = tempdir().unwrap();
+        let path = target.path().join("tool_star_");
+        let mut bij = BloodyIndianaJones::new_with_file_name(
+            url.to_string(),
+            path.to_str().unwrap().to_string(),
+            ProgressBar::hidden(),
+        );
+        make_tar(&bij.file_path, entries).await;
+        bij.unpack_and_all_that_stuff().await;
+        target
+    }
+
+    #[tokio::test]
+    async fn test_unpack_plain_tar_with_version_dots() {
+        // Regression: jbang ships native assets as a plain, uncompressed .tar
+        // (jbang-0.139.3-linux-x64.tar). Stripping ".tar" left
+        // "jbang-0.139.3-linux-x64", whose re-derived extension is "3-linux-x64",
+        // so the shared untar step was skipped and nothing got extracted -
+        // "Unable to locate jbang binary after download".
+        let target = unpack_url(
+            "http://example.com/jbang-0.139.3-linux-x64.tar",
+            &["jbang/bin/jbang", "jbang/bin/jbang.jar"],
+        )
+        .await;
+        let install_dir = target.path().join("tool_star_");
+        assert!(install_dir.join("bin").join("jbang").exists());
+        assert!(install_dir.join("bin").join("jbang.jar").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Plain uncompressed .tar archives were never unpacked. The code stripped the .tar extension to compute file_path_decomp, then the shared untar step re-checked that stripped name for a .tar extension - which is gone (and worse with version dots: jbang-0.139.3-linux-x64.tar yields ext '3-linux-x64'), so the untar never fired and the install dir stayed empty ("Unable to locate <tool> binary after download").

The untar branch only ever worked for compressed tars (.tgz/.tar.gz/.xz) that decompress to an intermediate name.tar. Untar the original file directly in the Some("tar") arm instead.

Surfaced by jbang shipping native-image assets as plain .tar, which the selector now prefers over the portable .zip.