### PR TITLE
github: direct API with token chain, ghapi.ggcmd.io proxy now opt-in

### DIFF
--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -299,6 +299,8 @@ jobs:
 
       - name: Run!
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
           sh gg.cmd -v ${{ matrix.cmd }}
@@ -344,6 +346,8 @@ jobs:
 
       - name: Run!
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
           sh gg.cmd -v ${{ matrix.cmd }}
@@ -390,6 +394,8 @@ jobs:
 
       - name: Run!
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
           sh gg.cmd -v ${{ matrix.cmd }}
@@ -426,6 +432,8 @@ jobs:
 
       - name: Run!
         shell: cmd
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           .\gg.cmd -v ${{ matrix.cmd }}
           echo "Nice, let's try again"
@@ -474,14 +482,16 @@ jobs:
           chmod +x "$HOME/.cache/gg/gg-dev/stage4"
 
       - name: Run!
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
 
-          # This is required for nodejs to run - not gg.cmd! 
+          # This is required for nodejs to run - not gg.cmd!
           if [ "${{ matrix.container }}" == "alpine" ]; then
             apk add libstdc++
           fi
-          
+
           sh gg.cmd -v ${{ matrix.cmd }}
           echo "Nice, let's try again"
           sh gg.cmd -v ${{ matrix.cmd }}

--- a/README.md
+++ b/README.md
@@ -418,6 +418,23 @@ export GG_CACHE_DIR="/path/to/custom/cache"
 
 **Note**: When `GG_CACHE_DIR` is set, it takes precedence over both global and local cache modes.
 
+## GitHub API access
+
+Tools hosted on GitHub are resolved through the GitHub API. Unauthenticated access is limited to 60
+requests/hour, so gg looks for a token in this order:
+
+1. `GG_GITHUB_TOKEN`, `GITHUB_TOKEN` or `GH_TOKEN` environment variables
+2. The [GitHub CLI](https://cli.github.com/) (`gh auth token`), if installed and logged in
+3. Anonymous access
+
+If you hit the rate limit, either set a token or log in with `gh auth login`. The error message may
+also have a hint or two.
+
+`GG_GITHUB_API_URL` can point gg at any GitHub API-compatible endpoint (e.g. your own proxy on a
+corporate network). Only the gg-specific `GG_GITHUB_TOKEN` is ever sent to a custom endpoint;
+`GITHUB_TOKEN`, `GH_TOKEN` and tokens borrowed from the `gh` CLI are only ever sent to
+`api.github.com`.
+
 ## Contributing
 
 We welcome contributions to `gg.cmd`. If you have an idea for a new feature or have found a bug, please open an issue on

--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -312,7 +312,9 @@ pub async fn prep(
     let executor_cmd = &executor.get_executor_cmd();
     let version_req = if let Some(ver) = &executor_cmd.version {
         Some(ver.to_version_req())
-    } else { executor.get_version_req() };
+    } else {
+        executor.get_version_req()
+    };
     let version_req_str = &version_req
         .as_ref()
         .map(|v| v.to_string())
@@ -376,11 +378,18 @@ pub async fn prep(
 
     pb.set_message("Fetching versions".to_string());
 
+    // Drop stale errors from earlier runs, or they get blamed on this tool
+    let _ = crate::github_utils::take_github_errors();
     let urls = executor.get_download_urls(input).await;
     pb.set_message(format!("{} versions", &urls.len()));
     debug!("{:?}", urls);
 
     if urls.is_empty() {
+        // Clear the bar first, or it eats the message
+        pb.finish_and_clear();
+        for reason in crate::github_utils::take_github_errors() {
+            eprintln!("{reason}");
+        }
         panic!("Did not find any download URL!");
     }
 
@@ -469,11 +478,7 @@ fn score_filename_match(filename: &str, tool_name: &str, version_re: &Regex) -> 
     }
 }
 
-fn get_url_matches(
-    urls: &[Download],
-    input: &AppInput,
-    executor: &dyn Executor,
-) -> Vec<Download> {
+fn get_url_matches(urls: &[Download], input: &AppInput, executor: &dyn Executor) -> Vec<Download> {
     let mut urls_match = urls
         .iter()
         .filter(|u| {

--- a/src/stage4/src/executors/github.rs
+++ b/src/stage4/src/executors/github.rs
@@ -6,7 +6,9 @@ use crate::executor::{
     find_jar_file, AppInput, AppPath, BinPattern, Download, Executor, ExecutorCmd, ExecutorDep,
     GgVersion,
 };
-use crate::github_utils::{create_github_client, detect_arch_from_name, detect_os_from_name};
+use crate::github_utils::{
+    create_github_client, detect_arch_from_name, detect_os_from_name, record_github_error,
+};
 use crate::target::Os::Windows;
 use crate::target::{Arch, Os, Variant};
 use log::debug;
@@ -67,7 +69,11 @@ impl GitHub {
     async fn detect_language_and_deps(&self) -> Vec<ExecutorDep> {
         let octocrab = create_github_client().unwrap();
 
-        if let Ok(repo_info) = octocrab.repos(&self.owner, &self.repo).get().await {
+        let repo_result = octocrab.repos(&self.owner, &self.repo).get().await;
+        if let Err(err) = &repo_result {
+            record_github_error(&format!("{}/{}", self.owner, self.repo), err);
+        }
+        if let Ok(repo_info) = repo_result {
             if let Some(language) = repo_info.language {
                 let language_str = language.as_str().unwrap_or("").to_lowercase();
                 return match language_str.as_str() {
@@ -205,7 +211,6 @@ impl Executor for GitHub {
 
         Box::pin(async move {
             let mut downloads: Vec<Download> = vec![];
-            // Shh don't tell anyone
             let octocrab = create_github_client().expect("Failed to create GitHub API client");
 
             let mut page: u32 = 1;
@@ -246,12 +251,13 @@ impl Executor for GitHub {
                                         asset.browser_download_url, os, arch
                                     );
                                     let is_musl = asset.name.to_lowercase().contains("musl")
-                                    && !matches!(os, Some(Os::Windows) | Some(Os::Mac));
-                                let variant = if is_musl {
-                                    Some(Variant::Musl)
-                                } else {
-                                    Some(Variant::Any)
-                                };downloads.push(Download {
+                                        && !matches!(os, Some(Os::Windows) | Some(Os::Mac));
+                                    let variant = if is_musl {
+                                        Some(Variant::Musl)
+                                    } else {
+                                        Some(Variant::Any)
+                                    };
+                                    downloads.push(Download {
                                         download_url: asset.browser_download_url.to_string(),
                                         version: GgVersion::new(release.tag_name.as_str()),
                                         os: os.or(Some(Os::Any)),
@@ -269,7 +275,7 @@ impl Executor for GitHub {
                         page += 1;
                     }
                     Err(err) => {
-                        debug!("Error: {err}");
+                        record_github_error(&format!("{owner}/{repo}"), &err);
                         break;
                     }
                 }
@@ -473,7 +479,10 @@ mod tests {
         let downloads = vec![dl("tool-linux-x64-musl.tar.gz", Variant::Musl, "1.0.0")];
         let result = prefer_libc_variant(downloads, false);
         assert_eq!(
-            result.iter().map(|d| d.download_url.clone()).collect::<Vec<_>>(),
+            result
+                .iter()
+                .map(|d| d.download_url.clone())
+                .collect::<Vec<_>>(),
             vec!["tool-linux-x64-musl.tar.gz"]
         );
         // Re-tagged Any so the shared matcher won't hard-drop the fallback.
@@ -511,7 +520,9 @@ mod tests {
         assert!(!GitHub::is_likely_binary(
             "deno-x86_64-unknown-linux-gnu.sha256sum"
         ));
-        assert!(!GitHub::is_likely_binary("deno-x86_64-pc-windows-msvc.sha256sum"));
+        assert!(!GitHub::is_likely_binary(
+            "deno-x86_64-pc-windows-msvc.sha256sum"
+        ));
         assert!(!GitHub::is_likely_binary("tool-linux-x64.zip.sha256"));
         assert!(!GitHub::is_likely_binary("tool-darwin-arm64.tar.gz.sig"));
         assert!(!GitHub::is_likely_binary("tool-windows-x64.zip.asc"));
@@ -522,7 +533,9 @@ mod tests {
         assert!(!GitHub::is_likely_binary("tool-linux-x64.zip.md5"));
 
         // ...but the actual archives still pass
-        assert!(GitHub::is_likely_binary("deno-x86_64-unknown-linux-gnu.zip"));
+        assert!(GitHub::is_likely_binary(
+            "deno-x86_64-unknown-linux-gnu.zip"
+        ));
         assert!(GitHub::is_likely_binary("deno-x86_64-pc-windows-msvc.zip"));
     }
 }

--- a/src/stage4/src/executors/ruby.rs
+++ b/src/stage4/src/executors/ruby.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use log::{debug, info};
 
 use crate::executor::{AppInput, AppPath, BinPattern, Download, Executor, ExecutorCmd, GgVersion};
-use crate::github_utils::{create_github_client, detect_arch_from_name};
+use crate::github_utils::{create_github_client, detect_arch_from_name, record_github_error};
 use crate::target::{Arch, Os, Variant};
 
 pub struct Ruby {
@@ -216,14 +216,17 @@ async fn get_truffleruby_urls(os: &Os) -> Vec<Download> {
 
     let octocrab = create_github_client().unwrap();
 
-    if let Ok(releases) = octocrab
+    let releases_result = octocrab
         .repos("ruby", "ruby-builder")
         .releases()
         .list()
         .per_page(50)
         .send()
-        .await
-    {
+        .await;
+    if let Err(err) = &releases_result {
+        record_github_error("ruby/ruby-builder", err);
+    }
+    if let Ok(releases) = releases_result {
         for release in releases.items {
             for asset in release.assets {
                 let name_lower = asset.name.to_lowercase();
@@ -282,14 +285,17 @@ async fn get_windows_ruby_urls() -> Vec<Download> {
 
     let octocrab = create_github_client().unwrap();
 
-    if let Ok(releases) = octocrab
+    let releases_result = octocrab
         .repos("oneclick", "rubyinstaller2")
         .releases()
         .list()
         .per_page(50)
         .send()
-        .await
-    {
+        .await;
+    if let Err(err) = &releases_result {
+        record_github_error("oneclick/rubyinstaller2", err);
+    }
+    if let Ok(releases) = releases_result {
         for release in releases.items {
             for asset in release.assets {
                 if !is_ruby_binary(&asset.name) {

--- a/src/stage4/src/github_utils.rs
+++ b/src/stage4/src/github_utils.rs
@@ -1,9 +1,187 @@
+use std::env;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use log::debug;
+
 use crate::target::{Arch, Os};
 
+const DEFAULT_GITHUB_API_URL: &str = "https://api.github.com";
+const PUBLIC_PROXY_URL: &str = "https://ghapi.ggcmd.io";
+
+fn first_nonempty(values: impl IntoIterator<Item = Option<String>>) -> Option<String> {
+    values
+        .into_iter()
+        .flatten()
+        .map(|v| v.trim().to_string())
+        .find(|v| !v.is_empty())
+}
+
+fn token_from_env() -> Option<String> {
+    first_nonempty(
+        ["GG_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"]
+            .iter()
+            .map(|key| env::var(key).ok()),
+    )
+}
+
+fn token_from_gh_cli() -> Option<String> {
+    // Own thread - a stuck keyring should not be able to hang gg forever
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(Command::new("gh").args(["auth", "token"]).output());
+    });
+    let output = rx.recv_timeout(Duration::from_secs(5)).ok()?.ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    first_nonempty([String::from_utf8(output.stdout).ok()])
+}
+
+fn github_token() -> Option<&'static str> {
+    static TOKEN: OnceLock<Option<String>> = OnceLock::new();
+    TOKEN
+        .get_or_init(|| {
+            if let Some(token) = token_from_env() {
+                debug!("Using GitHub token from environment");
+                return Some(token);
+            }
+            if let Some(token) = token_from_gh_cli() {
+                debug!("Using GitHub token from gh CLI");
+                return Some(token);
+            }
+            debug!("No GitHub token found, using anonymous API access");
+            None
+        })
+        .as_deref()
+}
+
+fn normalize_base_url(raw: Option<String>) -> String {
+    raw.map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_GITHUB_API_URL.to_string())
+}
+
+fn is_default_github_host(base_url: &str) -> bool {
+    base_url.eq_ignore_ascii_case(DEFAULT_GITHUB_API_URL)
+}
+
+fn hack_enabled() -> bool {
+    // Shh don't tell anyone (routes via the public proxy - on purpose only
+    // the rate-limit hint mentions it, keep it out of the README)
+    env::var("GG_GITHUB_API_HACK").is_ok_and(|v| {
+        matches!(
+            v.trim().to_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+pub fn github_api_base_url() -> String {
+    // An explicit GG_GITHUB_API_URL always wins over the hack switch.
+    if let Some(url) = first_nonempty([env::var("GG_GITHUB_API_URL").ok()]) {
+        return normalize_base_url(Some(url));
+    }
+    if hack_enabled() {
+        return PUBLIC_PROXY_URL.to_string();
+    }
+    DEFAULT_GITHUB_API_URL.to_string()
+}
+
 pub fn create_github_client() -> Result<octocrab::Octocrab, octocrab::Error> {
-    octocrab::Octocrab::builder()
-        .base_uri("https://ghapi.ggcmd.io/")?
-        .build()
+    let base_url = github_api_base_url();
+    let mut builder = match octocrab::Octocrab::builder().base_uri(&base_url) {
+        Ok(builder) => builder,
+        Err(e) => {
+            eprintln!("Invalid GitHub API URL '{base_url}' (set via GG_GITHUB_API_URL): {e}");
+            return Err(e);
+        }
+    };
+    // Only GG_GITHUB_TOKEN follows a custom URL. GITHUB_TOKEN/GH_TOKEN are
+    // often just lying around (CI etc.), and the gh token is the user's own
+    // login - not sending those anywhere but github.com
+    let token = if is_default_github_host(&base_url) {
+        github_token().map(|t| t.to_string())
+    } else {
+        let token = first_nonempty([env::var("GG_GITHUB_TOKEN").ok()]);
+        if token.is_some() && !base_url.starts_with("https://") {
+            eprintln!(
+                "Warning: sending GG_GITHUB_TOKEN to non-HTTPS endpoint {base_url} - the token travels unencrypted"
+            );
+        }
+        token
+    };
+    if let Some(token) = token {
+        builder = builder.personal_token(token);
+    }
+    builder.build()
+}
+
+/// Turn an octocrab error into a message that tells the user what to do
+/// about it, instead of the generic "Did not find any download URL!".
+pub fn explain_github_error(err: &octocrab::Error) -> String {
+    let base_url = github_api_base_url();
+    match err {
+        octocrab::Error::GitHub { source, .. } => {
+            let status = source.status_code.as_u16();
+            if status == 429 || source.message.to_lowercase().contains("rate limit") {
+                if is_default_github_host(&base_url) {
+                    format!(
+                        "GitHub API rate limit exceeded ({base_url}).\n\
+                         To fix, either:\n\
+                         \x20 - set GITHUB_TOKEN (or GG_GITHUB_TOKEN / GH_TOKEN)\n\
+                         \x20 - log in with the GitHub CLI: gh auth login\n\
+                         \x20 - ...or, between you and me: GG_GITHUB_API_HACK=1 ;)"
+                    )
+                } else {
+                    // Only GG_GITHUB_TOKEN goes to a custom endpoint, no
+                    // point suggesting tokens that would be ignored
+                    format!(
+                        "GitHub API rate limit exceeded ({base_url}).\n\
+                         To fix, either:\n\
+                         \x20 - set GG_GITHUB_TOKEN (the only token sent to a custom endpoint)\n\
+                         \x20 - unset GG_GITHUB_API_URL / GG_GITHUB_API_HACK to use api.github.com\n\
+                         \x20   with GITHUB_TOKEN or gh auth login"
+                    )
+                }
+            } else if status == 401 {
+                format!(
+                    "GitHub API rejected the token ({base_url}): {}\n\
+                     The token from GG_GITHUB_TOKEN/GITHUB_TOKEN/GH_TOKEN (or the gh CLI) looks\n\
+                     invalid or expired - refresh it, or unset it to use anonymous access.",
+                    source.message
+                )
+            } else {
+                format!("GitHub API error from {base_url}: {}", source.message)
+            }
+        }
+        octocrab::Error::Service { .. } | octocrab::Error::Hyper { .. } => {
+            format!(
+                "Could not reach {base_url} - check your network or proxy settings.\n\
+                 You can point gg at a different GitHub API endpoint with GG_GITHUB_API_URL."
+            )
+        }
+        _ => format!("GitHub API request failed: {err}"),
+    }
+}
+
+/// Failures stashed per repo (executors run concurrently) so the final "no
+/// download URL" error can say what happened. Can't print right away - the
+/// progress bars own stderr and would just eat it.
+static GITHUB_ERRORS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+pub fn record_github_error(scope: &str, err: &octocrab::Error) {
+    debug!("GitHub API error for {scope}: {err}");
+    let msg = format!("[{scope}] {}", explain_github_error(err));
+    let mut errors = GITHUB_ERRORS.lock().unwrap();
+    if !errors.contains(&msg) {
+        errors.push(msg);
+    }
+}
+
+pub fn take_github_errors() -> Vec<String> {
+    std::mem::take(&mut *GITHUB_ERRORS.lock().unwrap())
 }
 
 pub fn detect_os_from_name(name: &str) -> Option<Os> {
@@ -35,5 +213,64 @@ pub fn detect_arch_from_name(name: &str) -> Option<Arch> {
         Some(Arch::Any)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_nonempty_picks_first_set_value() {
+        assert_eq!(
+            first_nonempty([None, Some("  ".to_string()), Some("tok".to_string())]),
+            Some("tok".to_string())
+        );
+        assert_eq!(first_nonempty([None, None]), None);
+        assert_eq!(first_nonempty([Some("".to_string())]), None);
+    }
+
+    #[test]
+    fn test_first_nonempty_trims_whitespace() {
+        assert_eq!(
+            first_nonempty([Some("  token\n".to_string())]),
+            Some("token".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_base_url_defaults() {
+        assert_eq!(normalize_base_url(None), DEFAULT_GITHUB_API_URL);
+        assert_eq!(
+            normalize_base_url(Some("".to_string())),
+            DEFAULT_GITHUB_API_URL
+        );
+        assert_eq!(
+            normalize_base_url(Some("  ".to_string())),
+            DEFAULT_GITHUB_API_URL
+        );
+    }
+
+    #[test]
+    fn test_normalize_base_url_strips_trailing_slashes() {
+        assert_eq!(
+            normalize_base_url(Some("https://api.github.com/".to_string())),
+            "https://api.github.com"
+        );
+        assert_eq!(
+            normalize_base_url(Some("https://ghapi.ggcmd.io//".to_string())),
+            "https://ghapi.ggcmd.io"
+        );
+    }
+
+    #[test]
+    fn test_is_default_github_host() {
+        assert!(is_default_github_host("https://api.github.com"));
+        assert!(is_default_github_host("https://API.github.com"));
+        // trailing slash is stripped by normalize_base_url before this check
+        assert!(is_default_github_host(&normalize_base_url(Some(
+            "https://api.github.com/".to_string()
+        ))));
+        assert!(!is_default_github_host("https://ghapi.ggcmd.io"));
     }
 }

--- a/src/stage4/src/updater.rs
+++ b/src/stage4/src/updater.rs
@@ -5,6 +5,7 @@ use log::{info, warn};
 
 use crate::barus::create_barus;
 use crate::bloody_indiana_jones::BloodyIndianaJones;
+use crate::github_utils::{create_github_client, explain_github_error};
 
 async fn download_to_temp(temp_path: &str) -> Result<(), String> {
     let url = "https://github.com/eirikb/gg/releases/latest/download/gg.cmd";
@@ -152,11 +153,7 @@ fn move_temp_to_final(temp_path: &str, final_path: &str) -> Result<(), String> {
 }
 
 pub async fn check_gg_update(ver: &str) {
-    let octocrab = octocrab::Octocrab::builder()
-        .base_uri("https://ghapi.ggcmd.io/")
-        .unwrap()
-        .build()
-        .expect("Failed to create GitHub API client");
+    let octocrab = create_github_client().expect("Failed to create GitHub API client");
 
     match octocrab.repos("eirikb", "gg").releases().get_latest().await {
         Ok(release) => {
@@ -174,18 +171,15 @@ pub async fn check_gg_update(ver: &str) {
                 );
             }
         }
-        Err(_) => {
+        Err(err) => {
             println!("gg: Unable to check for updates");
+            println!("{}", explain_github_error(&err));
         }
     }
 }
 
 pub async fn perform_update(ver: &str, force: bool) {
-    let octocrab = octocrab::Octocrab::builder()
-        .base_uri("https://ghapi.ggcmd.io/")
-        .unwrap()
-        .build()
-        .expect("Failed to create GitHub API client");
+    let octocrab = create_github_client().expect("Failed to create GitHub API client");
 
     if !force {
         match octocrab.repos("eirikb", "gg").releases().get_latest().await {
@@ -199,8 +193,9 @@ pub async fn perform_update(ver: &str, force: bool) {
 
                 println!("Updating gg to version {}...", latest_version);
             }
-            Err(_) => {
+            Err(err) => {
                 println!("Failed to check for updates. Proceeding with download...");
+                println!("{}", explain_github_error(&err));
             }
         }
     } else {


### PR DESCRIPTION
All GitHub API calls used to go through a hardcoded proxy. Now gg talks straight to api.github.com and finds credentials in this order:

1. GG_GITHUB_TOKEN / GITHUB_TOKEN / GH_TOKEN env vars
2. gh auth token (if the GitHub CLI is installed and logged in, 5s cap)
3. anonymous

GG_GITHUB_API_URL points gg at any GitHub API-compatible endpoint. Only the gg-scoped GG_GITHUB_TOKEN is ever sent to a custom endpoint (with a warning if it is not HTTPS) - ambient GITHUB_TOKEN/GH_TOKEN and gh CLI tokens go nowhere but api.github.com.

Errors explain themselves now instead of hiding behind 'Did not find any download URL!': rate limits (429 or message) print remediation adapted to the active endpoint, 401 says the token looks stale, connect failures point at GG_GITHUB_API_URL, and a malformed URL names the env var. Failures are stashed per repo and printed after the progress bar is cleared, so concurrent executors don't eat or misattribute each other's diagnosis. ruby and the updater surface errors the same way.

CI test jobs get GITHUB_TOKEN - anonymous 60 req/hr on shared runner IPs would kill the matrix.

And GG_GITHUB_API_HACK=1... shh.

Fixes #282, helps #272