### PR TITLE
github: skip Android assets and prefer the plain build on Linux (#287)

### DIFF
--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -478,6 +478,19 @@ fn score_filename_match(filename: &str, tool_name: &str, version_re: &Regex) -> 
     }
 }
 
+/// Non-default build flavors (profiling, debug, older-CPU baseline) we only
+/// want when nothing plainer is on offer. A tiebreaker, so `tool-linux-x64.zip`
+/// beats `tool-linux-x64-baseline-profile.zip` when both fit the target.
+fn variant_noise(filename: &str) -> usize {
+    let tokens: Vec<&str> = filename
+        .split(|c: char| c == '-' || c == '_' || c == '.')
+        .collect();
+    ["profile", "debug", "baseline"]
+        .iter()
+        .filter(|flavor| tokens.contains(flavor))
+        .count()
+}
+
 fn get_url_matches(urls: &[Download], input: &AppInput, executor: &dyn Executor) -> Vec<Download> {
     let mut urls_match = urls
         .iter()
@@ -590,6 +603,12 @@ fn get_url_matches(urls: &[Download], input: &AppInput, executor: &dyn Executor)
             .cmp(&a.version.clone().map(|v| v.to_version()));
 
         match version_cmp {
+            std::cmp::Ordering::Equal => {}
+            other => return other,
+        }
+
+        let noise_cmp = variant_noise(&a_filename).cmp(&variant_noise(&b_filename));
+        match noise_cmp {
             std::cmp::Ordering::Equal => {}
             other => return other,
         }
@@ -948,6 +967,12 @@ mod tests {
                 other => return other,
             }
 
+            let noise_cmp = variant_noise(&a_filename).cmp(&variant_noise(&b_filename));
+            match noise_cmp {
+                std::cmp::Ordering::Equal => {}
+                other => return other,
+            }
+
             let a_specific = a.os != Some(Os::Any) || a.arch != Some(Arch::Any);
             let b_specific = b.os != Some(Os::Any) || b.arch != Some(Arch::Any);
 
@@ -998,6 +1023,27 @@ mod tests {
         assert_eq!(
             select_best_download(&downloads, "sccache", Os::Linux, Arch::Arm64),
             Some("sccache-v0.12.0-aarch64-unknown-linux-musl.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bun_prefers_plain_over_profile_and_baseline() {
+        // bun ships profiling/baseline flavors next to the plain binary; when
+        // they all fit the target the plainest one should win, not whatever
+        // GitHub happens to list first.
+        let release_text = r#"
+            bun-linux-x64-baseline-profile.zip
+            bun-linux-x64-baseline.zip
+            bun-linux-x64-profile.zip
+            bun-linux-x64.zip
+        "#;
+
+        let filenames = parse_release_assets(release_text);
+        let downloads = create_downloads(&filenames);
+
+        assert_eq!(
+            select_best_download(&downloads, "bun", Os::Linux, Arch::X86_64),
+            Some("bun-linux-x64.zip".to_string())
         );
     }
 

--- a/src/stage4/src/github_utils.rs
+++ b/src/stage4/src/github_utils.rs
@@ -186,6 +186,15 @@ pub fn take_github_errors() -> Vec<String> {
 
 pub fn detect_os_from_name(name: &str) -> Option<Os> {
     let name_lower = name.to_lowercase();
+    // Android assets carry "linux" too (bun-linux-x64-android-*), and we don't
+    // target Android. Delimited token only, or we'd drop desktop tools that
+    // just have "android" somewhere in the name.
+    if name_lower
+        .split(|c: char| c == '-' || c == '_' || c == '.')
+        .any(|part| part == "android")
+    {
+        return None;
+    }
     if name_lower.contains("darwin") || name_lower.contains("macos") || name_lower.contains("apple")
     {
         Some(Os::Mac)
@@ -260,6 +269,31 @@ mod tests {
         assert_eq!(
             normalize_base_url(Some("https://ghapi.ggcmd.io//".to_string())),
             "https://ghapi.ggcmd.io"
+        );
+    }
+
+    #[test]
+    fn test_detect_os_rejects_android() {
+        // darwin/windows too, not just linux - guard beats every OS keyword
+        assert_eq!(
+            detect_os_from_name("bun-linux-x64-android-baseline-profile.zip"),
+            None
+        );
+        assert_eq!(detect_os_from_name("bun-darwin-x64-android.zip"), None);
+        assert_eq!(detect_os_from_name("bun-windows-x64-android.zip"), None);
+    }
+
+    #[test]
+    fn test_detect_os_keeps_desktop_linux() {
+        assert_eq!(detect_os_from_name("bun-linux-x64.zip"), Some(Os::Linux));
+        assert_eq!(
+            detect_os_from_name("bun-linux-x64-baseline.zip"),
+            Some(Os::Linux)
+        );
+        // "android" fused into a bigger token shouldn't trip the guard
+        assert_eq!(
+            detect_os_from_name("mytool-linux-x64-noandroidhere.zip"),
+            Some(Os::Linux)
         );
     }
 


### PR DESCRIPTION
Android release assets carry "linux" in the name (e.g. bun-linux-x64-android-*), so they matched a desktop Linux target and could get picked - then the missing binary blew up with "os error 2". Treat an "android" token as unknown OS so those assets drop out.

Also add a tiebreaker: when several same-version assets fit the target, prefer the plainest one over -profile/-baseline/-debug flavors. bun's filenames have no embedded version, so every candidate scored equal and the sort just kept GitHub's order - picking bun-linux-x64-baseline-profile.zip instead of bun-linux-x64.zip.