### PR TITLE
stage1: keep the invoked symlink name so renamed gg.cmd works on macOS (#289)

### DIFF
--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -344,6 +344,20 @@ jobs:
           cp stage4 "$HOME/.cache/gg/gg-dev/stage4"
           chmod +x "$HOME/.cache/gg/gg-dev/stage4"
 
+      - name: Renamed symlink dispatches to the applet (#289)
+        if: matrix.cmd == 'node -v'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -x
+          ln -sf gg.cmd node.cmd
+          out=$(sh ./node.cmd --version 2>&1)
+          echo "$out"
+          # node prints "vX.Y.Z"; if gg ran itself it prints a bare version - so
+          # a v-prefixed semver proves the symlink name reached applet dispatch.
+          echo "$out" | grep -Eq '^v[0-9]+\.[0-9]' || { echo "#289: node.cmd ran gg, not node"; exit 1; }
+
       - name: Run!
         shell: bash
         env:

--- a/src/stage1/stage1.sh
+++ b/src/stage1/stage1.sh
@@ -1,5 +1,8 @@
-if command -v realpath >/dev/null 2>&1; then
-  export GG_CMD_PATH="$(realpath -s "$0" 2>/dev/null || readlink -f "$0" 2>/dev/null || echo "$0")"
+# Keep the name we were invoked as - a symlink like node.cmd -> gg.cmd is the
+# applet, so don't resolve it. realpath -s is GNU-only and readlink -f resolves
+# the link, so cd/pwd + basename instead, same on macOS and Linux (#289).
+if GG_CMD_PATH="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"; then
+  export GG_CMD_PATH="$GG_CMD_PATH/$(basename "$0")"
 else
   export GG_CMD_PATH="$0"
 fi


### PR DESCRIPTION
GG_CMD_PATH used realpath -s (GNU-only) then readlink -f, which on macOS' BSD tools resolved node.cmd back to gg.cmd - so the applet name was lost and gg ran itself. Compute the path with cd/pwd + basename, which never resolves the last component and is identical on macOS and Linux. Add a macOS CI step that renames via symlink and checks dispatch.