### PR TITLE
github: run jar-only releases via java, stop re-downloading (#244)

### DIFF
--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -255,6 +255,16 @@ pub trait Executor {
         input: &'a AppInput,
     ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>>;
     fn get_bins(&self, input: &AppInput) -> Vec<BinPattern>;
+    // Same as get_bins, but the executor can look at what actually got extracted
+    // (e.g. a jar-only release picks `java` directly instead of guessing a bin).
+    fn get_bins_for_path(&self, input: &AppInput, _app_path: &AppPath) -> Vec<BinPattern> {
+        self.get_bins(input)
+    }
+    // A jar tool runs via `java` from a separate dependency dir the cache check
+    // can't see, so the jar being there is what makes the cached dir a hit.
+    fn cached_install_is_valid(&self, _app_path: &AppPath) -> bool {
+        false
+    }
     fn get_name(&self) -> &str;
     fn get_deps<'a>(
         &'a self,
@@ -377,7 +387,14 @@ pub async fn prep(
             let path_vars = bin_path_vars(executor, &app_path_ok);
             let sep = if cfg!(windows) { ";" } else { ":" };
             let all_paths = path_vars.join(sep);
-            if resolve_bin_path(&executor.get_bins(input), &path_vars, &all_paths).is_some() {
+            if resolve_bin_path(
+                &executor.get_bins_for_path(input, &app_path_ok),
+                &path_vars,
+                &all_paths,
+            )
+            .is_some()
+                || executor.cached_install_is_valid(&app_path_ok)
+            {
                 return Ok(app_path_ok);
             }
             info!(
@@ -739,7 +756,7 @@ pub async fn try_run(
         _ => ":",
     });
     info!("PATH: {all_paths}");
-    let bins = executor.get_bins(input);
+    let bins = executor.get_bins_for_path(input, &app_path);
     info!("Trying to find these bins: {:?}", bins);
     if let Some(bin_path) = resolve_bin_path(&bins, &path_vars, &all_paths) {
         info!("Executing: {:?}. With args:{:?}", bin_path, args);

--- a/src/stage4/src/executors/github.rs
+++ b/src/stage4/src/executors/github.rs
@@ -168,6 +168,26 @@ impl GitHub {
 
         false
     }
+
+    // A jar-only release (RepoSense) runs via `java -jar`. A jar next to a real
+    // binary doesn't count - the binary wins, no forced java. #244
+    fn should_run_as_jar(&self, app_path: &AppPath) -> bool {
+        if self.predefined_bins.is_some() || find_jar_file(app_path).is_none() {
+            return false;
+        }
+        let names = [
+            self.repo.clone(),
+            self.repo.to_lowercase(),
+            format!("{}.exe", self.repo),
+            format!("{}.exe", self.repo.to_lowercase()),
+        ];
+        let has_native_binary = ["bin", "."].iter().any(|sub| {
+            names
+                .iter()
+                .any(|n| app_path.install_dir.join(sub).join(n).is_file())
+        });
+        !has_native_binary
+    }
 }
 
 /// Prefer the host's libc variant, falling back to the other when it's the only
@@ -318,16 +338,32 @@ impl Executor for GitHub {
         patterns
     }
 
+    fn get_bins_for_path(&self, input: &AppInput, app_path: &AppPath) -> Vec<BinPattern> {
+        // For a jar run, resolve `java` directly - the generic patterns match a
+        // JDK helper (jimage, jabswitch, jar, ...) from the java dep's bin dir
+        // before java. #244
+        if self.should_run_as_jar(app_path) {
+            return vec![BinPattern::Exact("java".to_string())];
+        }
+        self.get_bins(input)
+    }
+
+    fn cached_install_is_valid(&self, app_path: &AppPath) -> bool {
+        self.should_run_as_jar(app_path)
+    }
+
     fn get_name(&self) -> &str {
         &self.repo
     }
 
     fn customize_args(&self, input: &AppInput, app_path: &AppPath) -> Vec<String> {
-        if let Some(jar_name) = find_jar_file(app_path) {
-            if let Some(jar_path) = app_path.install_dir.join(&jar_name).to_str() {
-                let mut args = vec!["-jar".to_string(), jar_path.to_string()];
-                args.extend_from_slice(&input.app_args);
-                return args;
+        if self.should_run_as_jar(app_path) {
+            if let Some(jar_name) = find_jar_file(app_path) {
+                if let Some(jar_path) = app_path.install_dir.join(&jar_name).to_str() {
+                    let mut args = vec!["-jar".to_string(), jar_path.to_string()];
+                    args.extend_from_slice(&input.app_args);
+                    return args;
+                }
             }
         }
         input.app_args.clone()
@@ -537,5 +573,34 @@ mod tests {
             "deno-x86_64-unknown-linux-gnu.zip"
         ));
         assert!(GitHub::is_likely_binary("deno-x86_64-pc-windows-msvc.zip"));
+    }
+
+    #[test]
+    fn test_should_run_as_jar() {
+        use std::fs::File;
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = ExecutorCmd {
+            cmd: "gh/reposense/RepoSense".to_string(),
+            version: None,
+            distribution: None,
+            include_tags: std::collections::HashSet::new(),
+            exclude_tags: std::collections::HashSet::new(),
+            gems: None,
+        };
+        let gh = GitHub::new(cmd, "reposense".to_string(), "RepoSense".to_string());
+        let app_path = AppPath {
+            install_dir: dir.path().to_path_buf(),
+        };
+
+        // No jar -> not a jar run
+        assert!(!gh.should_run_as_jar(&app_path));
+
+        // Jar and no native binary -> run via java
+        File::create(dir.path().join("RepoSense.jar")).unwrap();
+        assert!(gh.should_run_as_jar(&app_path));
+
+        // A native binary next to the jar -> binary wins, no forced java
+        File::create(dir.path().join("RepoSense")).unwrap();
+        assert!(!gh.should_run_as_jar(&app_path));
     }
 }

--- a/src/stage4/src/executors/openapigenerator.rs
+++ b/src/stage4/src/executors/openapigenerator.rs
@@ -29,6 +29,15 @@ impl Executor for OpenAPIGenerator {
         vec![BinPattern::Exact("java".to_string())]
     }
 
+    // Runs via `java` from a separate dep dir, so the cache check can't resolve
+    // a bin in our own dir - the jar being there is what makes it a hit (#244)
+    fn cached_install_is_valid(&self, app_path: &AppPath) -> bool {
+        app_path
+            .install_dir
+            .join("openapi-generator-cli.jar")
+            .is_file()
+    }
+
     fn get_name(&self) -> &str {
         "openapi"
     }


### PR DESCRIPTION
A jar-only GitHub release (RepoSense) resolved a JDK helper (jimage on linux, jabswitch on windows) instead of java, and re-downloaded every run - the cache check looked for a bin in the app's own dir while java lives in a separate dependency dir.

Add get_bins_for_path and cached_install_is_valid to the Executor trait (behavior-preserving defaults). github resolves java directly for a jar run and treats the jar's presence as a cache hit. Same cache fix for the openapi executor, which had the identical re-download.