### PR TITLE
update: resolve tool names through the registry, not executor names

### DIFF
--- a/src/stage4/src/checker.rs
+++ b/src/stage4/src/checker.rs
@@ -1,5 +1,7 @@
 use crate::barus::create_barus;
-use crate::executor::{prep, AppInput, GgMeta};
+use crate::cli::{starts_like_version, strip_version_prefix};
+use crate::executor::{prep, AppInput, ExecutorCmd, GgMeta, GgVersionReq};
+use crate::tools::{canonical_name, get_all_tools, registry_name};
 use crate::updater;
 use crate::Executor;
 use futures_util::future::join_all;
@@ -7,6 +9,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{debug, info};
 use std::collections::HashMap;
 use std::fs;
+use std::process::ExitCode;
 use tokio::sync::Semaphore;
 
 struct UpdateInfo {
@@ -18,6 +21,90 @@ struct UpdateInfo {
     is_major_update: bool,
     path: std::path::PathBuf,
     executor: Box<dyn Executor>,
+}
+
+fn executor_for(name: &str) -> Option<Box<dyn Executor>> {
+    <dyn Executor>::new(ExecutorCmd {
+        cmd: name.to_string(),
+        version: None,
+        distribution: None,
+        include_tags: Default::default(),
+        exclude_tags: Default::default(),
+        gems: None,
+    })
+}
+
+/// What to tell someone to run when a tool isn't installed, or None when the
+/// name isn't a tool at all.
+fn install_name(name: &str) -> Option<String> {
+    if executor_for(name).is_some() {
+        return Some(name.to_string());
+    }
+    // matches_requested_tool takes repo names off cached tools, so "cli" has
+    // to be known here too or it is a typo only while gh is uninstalled.
+    // `gg cli` installs nothing though, so name the tool that owns the repo
+    get_all_tools()
+        .iter()
+        .find(|tool| executor_for(tool.name).is_some_and(|e| e.get_name() == name))
+        .map(|tool| tool.name.to_string())
+}
+
+/// The gg.toml pin for a tool. Exact key first, then the registry name -
+/// forward only, like cli.rs. An `npx` key answering a `node` request would
+/// have update enforce a pin install never applies.
+fn config_pin<'a>(
+    dependencies: &'a HashMap<String, String>,
+    base_name: &str,
+    requested_name: &str,
+) -> Option<&'a str> {
+    dependencies
+        .get(base_name)
+        .or_else(|| dependencies.get(requested_name))
+        .map(|value| value.as_str())
+}
+
+/// Split `node@18` into name and selector. Built-in commands skip the command
+/// parser, so update does it itself.
+fn split_selector(tool_name: &str) -> (&str, Option<&str>) {
+    match tool_name.split_once('@') {
+        Some((base, version)) => (base, Some(version)),
+        None => (tool_name, None),
+    }
+}
+
+/// The version out of an `@selector`, `+tag` and `-distribution` stripped the
+/// way cli.rs does it. Err carries the part that would not parse.
+fn selector_version_req(selector: &str) -> Result<Option<GgVersionReq>, &str> {
+    // Tags first - built-in commands skip the tag parser, so java@17+jdk
+    // still has them glued on
+    let version_part = selector.split('+').next().unwrap_or(selector);
+    let version_part = match version_part.split_once('-') {
+        // java@-jdk and java@-zulu are distribution only, no version to pin
+        // (cli.rs does the same, and README documents java@-jdk+jre)
+        Some(("", _)) => return Ok(None),
+        // java@17-zulu is version-distribution, but bun@bun-v1.2.0 is all
+        // version (#293), so only split when a version comes first
+        Some((before, _)) if starts_like_version(before) => before,
+        _ => version_part,
+    };
+    if version_part.is_empty() {
+        return Ok(None);
+    }
+    match GgVersionReq::new(&strip_version_prefix(version_part)) {
+        Some(req) => Ok(Some(req)),
+        None => Err(version_part),
+    }
+}
+
+/// Does this cached tool answer to the name the user asked to update?
+/// `requested_name` is `tool_name` resolved through the registry.
+fn matches_requested_tool(executor: &dyn Executor, tool_name: &str, requested_name: &str) -> bool {
+    registry_name(executor) == requested_name
+        // The executor name stays accepted so `update <repo-name>` works
+        || executor.get_name() == tool_name
+        // ...and the exact string it was installed with - the only name a
+        // raw gh/owner/repo has
+        || executor.get_executor_cmd().cmd == tool_name
 }
 
 async fn check_tool_update(
@@ -69,7 +156,7 @@ async fn check_tool_update(
             let version_selector = meta.cmd.to_version_selector();
 
             return Some(UpdateInfo {
-                tool_name: executor.get_name().to_string(),
+                tool_name: registry_name(&*executor),
                 version_selector,
                 current_version: current_version.map(|v| v.to_string()),
                 latest_version: latest_version.map(|v| v.to_string()),
@@ -156,24 +243,26 @@ pub async fn check_or_update_all(
 
     let mut tool_spinners: HashMap<String, ProgressBar> = HashMap::new();
 
-    for (meta, _) in &metas {
+    for (meta, path) in &metas {
         if let Some(executor) = <dyn Executor>::new(meta.cmd.clone()) {
-            let tool_name = executor.get_name().to_string();
+            let tool_name = registry_name(&*executor);
             let version_selector = meta.cmd.to_version_selector();
 
-            let unique_key = if version_selector.is_empty() {
-                tool_name.clone()
+            let label = if version_selector.is_empty() {
+                tool_name
             } else {
                 format!("{}{}", tool_name, version_selector)
             };
 
             let pb = m.add(ProgressBar::new_spinner());
             pb.set_style(spinner_style.clone());
-            pb.set_prefix(format!("{:<20}", unique_key));
+            pb.set_prefix(format!("{:<20}", label));
             pb.set_message("checking...");
             pb.enable_steady_tick(std::time::Duration::from_millis(80));
 
-            tool_spinners.insert(unique_key, pb);
+            // Keyed by cache path, not name: ruby, gem, irb and bundle all
+            // resolve to "ruby", and a key collision leaves the loser spinning
+            tool_spinners.insert(path.to_string_lossy().to_string(), pb);
         }
     }
 
@@ -184,15 +273,11 @@ pub async fn check_or_update_all(
             let tool_spinners = tool_spinners.clone();
             async move {
                 let _permit = semaphore.acquire().await.unwrap();
+                let spinner_key = path.to_string_lossy().to_string();
                 let result = check_tool_update(meta, path, input).await;
 
-                if let Some(ref info) = result {
-                    let unique_key = if info.version_selector.is_empty() {
-                        info.tool_name.clone()
-                    } else {
-                        format!("{}{}", info.tool_name, info.version_selector)
-                    };
-                    if let Some(pb) = tool_spinners.get(&unique_key) {
+                if result.is_some() {
+                    if let Some(pb) = tool_spinners.get(&spinner_key) {
                         pb.finish_with_message("done");
                     }
                 }
@@ -202,11 +287,7 @@ pub async fn check_or_update_all(
         })
         .collect();
 
-    let update_infos: Vec<UpdateInfo> = join_all(check_tasks)
-        .await
-        .into_iter()
-        .flatten()
-        .collect();
+    let update_infos: Vec<UpdateInfo> = join_all(check_tasks).await.into_iter().flatten().collect();
 
     m.clear().unwrap();
 
@@ -297,44 +378,79 @@ pub async fn check_or_update_tool(
     allow_major: bool,
     force: bool,
     config: &crate::config::GgConfig,
-) {
+) -> ExitCode {
     let metas = get_all_tool_metas().await;
 
-    let config_version = config.dependencies.get(tool_name);
+    let (base_name, selector_version) = split_selector(tool_name);
+    let requested_name = canonical_name(base_name);
 
-    let matching_metas: Vec<_> = metas
-        .into_iter()
-        .filter(|(meta, _)| {
-            if let Some(executor) = <dyn Executor>::new(meta.cmd.clone()) {
-                let name_matches = executor.get_name() == tool_name;
+    let config_version = config_pin(&config.dependencies, base_name, &requested_name);
 
-                if let Some(config_ver) = config_version {
-                    if let Some(version_req) = crate::executor::GgVersionReq::new(config_ver) {
-                        if let Some(meta_version) = &meta.download.version {
-                            return name_matches
-                                && version_req
-                                    .to_version_req()
-                                    .matches(&meta_version.to_version());
-                        }
-                    }
-                }
-
-                name_matches
-            } else {
-                false
+    // An explicit @version beats a gg.toml pin. A selector that will not parse
+    // is not the same as no selector - drop it and we check everything, exit 0
+    let version_filter = match selector_version {
+        Some(selector) => match selector_version_req(selector) {
+            Ok(req) => req,
+            Err(bad) => {
+                eprintln!(
+                    "Invalid version '{}' in '{}'. Versions look like @18, @2.95 or @1.2.3",
+                    bad, tool_name
+                );
+                return ExitCode::FAILURE;
             }
-        })
+        },
+        None => config_version.and_then(GgVersionReq::new),
+    };
+
+    let name_matches = |meta: &GgMeta| match <dyn Executor>::new(meta.cmd.clone()) {
+        Some(executor) => matches_requested_tool(&*executor, base_name, &requested_name),
+        None => false,
+    };
+
+    let named_metas: Vec<_> = metas
+        .into_iter()
+        .filter(|(meta, _)| name_matches(meta))
+        .collect();
+    let named_count = named_metas.len();
+
+    let matching_metas: Vec<_> = named_metas
+        .into_iter()
+        .filter(
+            |(meta, _)| match (&version_filter, &meta.download.version) {
+                (Some(req), Some(version)) => req.to_version_req().matches(&version.to_version()),
+                _ => true,
+            },
+        )
         .collect();
 
     if matching_metas.is_empty() {
-        println!(
-            "Tool '{}' not found in cache. Install it first by running: gg {}",
-            tool_name, tool_name
-        );
-        return;
+        // Not installed is normal, not a failure - callers update before they
+        // install (postmortemthis does this per agent), so exit 0 stays.
+        // A name that is not a tool at all is a real error though
+        return if named_count > 0 {
+            // Installed, just not in the version that was asked for
+            println!(
+                "No cached {} matches {}. Install it by running: gg {}",
+                requested_name, tool_name, tool_name
+            );
+            ExitCode::SUCCESS
+        } else if let Some(install) = install_name(base_name) {
+            println!(
+                "{} is not installed yet, nothing to update. Install it by running: gg {}",
+                tool_name, install
+            );
+            ExitCode::SUCCESS
+        } else {
+            eprintln!(
+                "Unknown tool '{}'. Run 'gg tools' to see the available tools.",
+                tool_name
+            );
+            ExitCode::FAILURE
+        };
     }
 
     let mut update_available = false;
+    let mut update_failed = false;
 
     for (meta, path) in matching_metas {
         if let Some(info) = check_tool_update(meta, path, input).await {
@@ -359,13 +475,23 @@ pub async fn check_or_update_tool(
                 if let Some(parent) = info.path.parent() {
                     if fs::remove_dir_all(parent).is_ok() {
                         let pb = create_barus();
-                        let _ = prep(&*info.executor, input, &pb).await;
-                        println!("Successfully updated {}", display_name);
+                        // Cache dir is already gone, so a failed prep leaves
+                        // the tool uninstalled - "Successfully updated" and
+                        // exit 0 there is how you lose a tool quietly
+                        match prep(&*info.executor, input, &pb).await {
+                            Ok(_) => println!("Successfully updated {}", display_name),
+                            Err(e) => {
+                                eprintln!("Failed to update {}: {}", display_name, e);
+                                update_failed = true;
+                            }
+                        }
                     } else {
-                        println!("Unable to update {}", display_name);
+                        eprintln!("Unable to update {}", display_name);
+                        update_failed = true;
                     }
                 } else {
-                    println!("Unable to update {}", display_name);
+                    eprintln!("Unable to update {}", display_name);
+                    update_failed = true;
                 }
             } else if !info.needs_update {
                 println!("{}: Already up to date (version {})", display_name, current);
@@ -388,5 +514,265 @@ pub async fn check_or_update_tool(
 
     if update_available {
         println!("Run 'update {} -u' to update.", tool_name);
+    }
+
+    if update_failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::{Download, ExecutorCmd, GgVersionReq};
+    use std::collections::HashSet;
+
+    fn meta_for(cmd: &str) -> GgMeta {
+        GgMeta {
+            version_req: GgVersionReq::new("*").unwrap(),
+            download: Download::new("https://example.com/x.tar.gz".to_string(), "1.0.0", None),
+            cmd: ExecutorCmd {
+                cmd: cmd.to_string(),
+                version: None,
+                distribution: None,
+                include_tags: HashSet::new(),
+                exclude_tags: HashSet::new(),
+                gems: None,
+            },
+        }
+    }
+
+    fn name_for(cmd: &str) -> String {
+        let executor = <dyn Executor>::new(meta_for(cmd).cmd).unwrap();
+        registry_name(&*executor)
+    }
+
+    #[test]
+    fn test_registry_name_uses_tool_name_not_repo() {
+        // Repo differs from the tool name, so `update <tool>` used to miss
+        assert_eq!(name_for("gh"), "gh"); // repo cli/cli
+        assert_eq!(name_for("git"), "git"); // repo eirikb/portable-git
+        assert_eq!(name_for("antigravity"), "antigravity"); // repo antigravity-cli
+    }
+
+    #[test]
+    fn test_registry_name_folds_aliases() {
+        assert_eq!(name_for("claude-code"), "claude");
+        assert_eq!(name_for("antigravity-cli"), "antigravity");
+        assert_eq!(name_for("agy"), "antigravity");
+        assert_eq!(name_for("npx"), "node");
+    }
+
+    #[test]
+    fn test_registry_name_falls_back_for_unregistered() {
+        // A raw gh/owner/repo is not in the registry - keep the executor name
+        assert_eq!(
+            name_for("gh/google-antigravity/antigravity-cli"),
+            "antigravity-cli"
+        );
+    }
+
+    /// `cached` is what the cache was installed as, `asked` what gets typed
+    /// at `gg update <asked>`
+    fn matches(cached: &str, asked: &str) -> bool {
+        let executor = <dyn Executor>::new(meta_for(cached).cmd).unwrap();
+        matches_requested_tool(&*executor, asked, &canonical_name(asked))
+    }
+
+    #[test]
+    fn test_matches_primary_name_when_repo_differs() {
+        assert!(matches("gh", "gh"));
+        assert!(matches("git", "git"));
+        assert!(matches("antigravity", "antigravity"));
+    }
+
+    #[test]
+    fn test_matches_aliases_either_way() {
+        assert!(matches("claude", "claude-code"));
+        assert!(matches("claude-code", "claude"));
+        assert!(matches("node", "npx"));
+        assert!(matches("antigravity", "agy"));
+    }
+
+    #[test]
+    fn test_matches_repo_name_still_accepted() {
+        // These worked before the fix by accident, keep them working
+        assert!(matches("gh", "cli"));
+        assert!(matches("git", "portable-git"));
+    }
+
+    #[test]
+    fn test_install_name_separates_typos_from_not_installed() {
+        // Real tools that may not be installed - these have to stay exit 0
+        for name in [
+            "vibe",
+            "gh",
+            "claude-code",
+            "antigravity-cli",
+            "gh/google-antigravity/antigravity-cli",
+        ] {
+            assert_eq!(install_name(name).as_deref(), Some(name));
+        }
+
+        // Repo names too, and `gg cli` installs nothing, so point at the tool
+        assert_eq!(install_name("cli").as_deref(), Some("gh"));
+        assert_eq!(install_name("portable-git").as_deref(), Some("git"));
+
+        // Not tools at all - these are the ones worth failing on
+        for name in ["totally-bogus-tool", "", "gh/no-repo-part"] {
+            assert_eq!(install_name(name), None, "{name}");
+        }
+    }
+
+    /// A still-attached selector must not read as a typo
+    #[test]
+    fn test_version_selector_is_split_off_the_name() {
+        for (input, base, version) in [
+            ("node@18", "node", Some("18")),
+            ("gh@2.95", "gh", Some("2.95")),
+            ("java@17", "java", Some("17")),
+            ("java@-jdk+jre", "java", Some("-jdk+jre")),
+            // First @ wins, same as cli.rs taking parts[0] of split("@")
+            ("node@18@extra", "node", Some("18@extra")),
+            ("claude-code", "claude-code", None),
+            (
+                "gh/google-antigravity/antigravity-cli",
+                "gh/google-antigravity/antigravity-cli",
+                None,
+            ),
+        ] {
+            assert_eq!(split_selector(input), (base, version), "splitting {input}");
+            assert!(
+                install_name(base).is_some(),
+                "{input} must not read as unknown"
+            );
+        }
+    }
+
+    #[test]
+    fn test_selector_version_req() {
+        let ok = |s: &str| selector_version_req(s).unwrap().map(|r| r.to_version_req());
+
+        // Has to be an error, not "no filter" - that checked everything, exit 0
+        assert_eq!(selector_version_req("bogus").err(), Some("bogus"));
+        assert_eq!(selector_version_req("lts").err(), Some("lts"));
+
+        // Distribution with no version pins nothing (README has java@-jdk+jre)
+        assert!(ok("-jdk").is_none());
+        assert!(ok("-zulu").is_none());
+        assert!(ok("-jdk+jre").is_none());
+
+        // Tags and distribution come off, the version survives
+        assert!(ok("18").unwrap().matches(&"18.20.8".parse().unwrap()));
+        assert!(ok("17+jdk").unwrap().matches(&"17.0.1".parse().unwrap()));
+        assert!(ok("17-zulu").unwrap().matches(&"17.0.1".parse().unwrap()));
+        // bun@bun-v1.2.0 is all version, not version-distribution (#293)
+        assert!(ok("bun-v1.2.0").unwrap().matches(&"1.2.0".parse().unwrap()));
+
+        // Nothing to pin is fine, that is not the same as unparseable
+        assert!(ok("").is_none());
+        assert!(ok("+jdk").is_none());
+    }
+
+    fn pins(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_config_pin_prefers_exact_key() {
+        let deps = pins(&[("node", "18"), ("npx", "20")]);
+
+        // Both keys resolve to "node", so without exact-key-first this picks
+        // whichever the HashMap felt like today
+        assert_eq!(config_pin(&deps, "node", "node"), Some("18"));
+        assert_eq!(config_pin(&deps, "npx", "node"), Some("20"));
+
+        // Forward only, the direction cli.rs resolves an install with
+        let only_node = pins(&[("node", "18")]);
+        assert_eq!(config_pin(&only_node, "npx", "node"), Some("18"));
+
+        // ...and not the reverse, or update pins what install would not
+        let only_npx = pins(&[("npx", "20")]);
+        assert_eq!(config_pin(&only_npx, "node", "node"), None);
+
+        assert_eq!(config_pin(&only_node, "deno", "deno"), None);
+    }
+
+    /// Puts GG_CACHE_DIR back on the way out, panic or not, or a failed assert
+    /// leaves the rest of the binary pointed at a deleted dir
+    struct CacheDirGuard(Option<String>);
+
+    impl Drop for CacheDirGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => std::env::set_var("GG_CACHE_DIR", previous),
+                None => std::env::remove_var("GG_CACHE_DIR"),
+            }
+        }
+    }
+
+    /// One test for every cache-dependent assertion: GG_CACHE_DIR is process
+    /// global and tests run in parallel, so splitting these would race.
+    #[tokio::test]
+    async fn test_update_exit_codes() {
+        let _guard = CacheDirGuard(std::env::var("GG_CACHE_DIR").ok());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("GG_CACHE_DIR", dir.path());
+
+        // Without that set_var this globs the real cache and the asserts below
+        // go online, so fail here instead
+        assert!(get_all_tool_metas().await.is_empty());
+
+        let input = AppInput {
+            target: crate::target::Target::parse_with_overrides(
+                "x86_64-unknown-linux-gnu",
+                None,
+                None,
+            ),
+            app_args: vec![],
+        };
+        let config = crate::config::GgConfig {
+            dependencies: HashMap::new(),
+            aliases: HashMap::new(),
+        };
+        let run = |name: &'static str| {
+            let input = &input;
+            let config = &config;
+            async move { check_or_update_tool(input, name, false, false, false, config).await }
+        };
+
+        // Not installed is normal - a nonzero here breaks callers
+        assert_eq!(run("vibe").await, ExitCode::SUCCESS);
+        assert_eq!(run("gh").await, ExitCode::SUCCESS);
+        // Repo name, so it must not flip to "unknown" on an empty cache
+        assert_eq!(run("cli").await, ExitCode::SUCCESS);
+        // Selector still attached, must not read as a typo
+        assert_eq!(run("node@18").await, ExitCode::SUCCESS);
+
+        // Not a tool at all, and a version that will not parse
+        assert_eq!(run("totally-bogus-tool").await, ExitCode::FAILURE);
+        assert_eq!(run("gh@bogus").await, ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn test_matches_raw_github_by_exact_name() {
+        // The only name a raw gh/owner/repo answers to
+        let raw = "gh/google-antigravity/antigravity-cli";
+        assert!(matches(raw, raw));
+        // ...and it must not swallow the registry tool with the same repo
+        assert!(!matches("antigravity", raw));
+    }
+
+    #[test]
+    fn test_does_not_match_other_tools() {
+        assert!(!matches("gh", "git"));
+        assert!(!matches("claude", "codex"));
+        assert!(!matches("node", "deno"));
+        assert!(!matches("antigravity", "gemini-cli"));
     }
 }

--- a/src/stage4/src/cli.rs
+++ b/src/stage4/src/cli.rs
@@ -316,7 +316,7 @@ impl Cli {
 /// Strip a product or `v` prefix off a version, keeping any leading range
 /// operator and partial form: "bun-v1.2.0" -> "1.2.0", "=v1.2.0" -> "=1.2.0",
 /// "^18" -> "^18". Left untouched if there's no version in it.
-fn strip_version_prefix(version: &str) -> String {
+pub(crate) fn strip_version_prefix(version: &str) -> String {
     let op_end = version
         .find(|c: char| !matches!(c, '^' | '~' | '=' | '<' | '>'))
         .unwrap_or(version.len());
@@ -330,7 +330,7 @@ fn strip_version_prefix(version: &str) -> String {
 /// True when `s` starts like a version (optional operator, optional `v`, then a
 /// digit), so it's the version half of `version-distribution`, not a product
 /// prefix. Skip the operator too, or "^17-temurin" loses its distribution.
-fn starts_like_version(s: &str) -> bool {
+pub(crate) fn starts_like_version(s: &str) -> bool {
     let s = s.trim_start_matches(['^', '~', '=', '<', '>']);
     let s = s.strip_prefix(['v', 'V']).unwrap_or(s);
     s.starts_with(|c: char| c.is_ascii_digit())

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -29,7 +29,7 @@ mod target;
 mod tools;
 mod updater;
 
-use crate::tools::{get_all_tools, get_tool_info, ToolCategory};
+use crate::tools::{canonical_name, get_all_tools, get_tool_info, registry_name, ToolCategory};
 
 fn print_help(ver: &str) {
     println!(
@@ -190,6 +190,21 @@ fn print_tool_info(tool: &tools::ToolInfo) {
     }
 }
 
+/// Is this dependency already covered? Registry names on both sides: gh
+/// depends on "git" but a built git executor calls itself "portable-git", so
+/// comparing those raw built a second executor over the same cache dir and
+/// prepped both at once.
+fn dep_satisfied(
+    executors: &[Box<dyn Executor>],
+    to_add: &[Box<dyn Executor>],
+    processed: &std::collections::HashSet<String>,
+    dep_name: &str,
+) -> bool {
+    executors.iter().any(|e| registry_name(&**e) == dep_name)
+        || to_add.iter().any(|e| registry_name(&**e) == dep_name)
+        || processed.contains(dep_name)
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     let ver = option_env!("VERSION").unwrap_or("dev");
@@ -315,7 +330,7 @@ async fn main() -> ExitCode {
                         }
                     }
                     Some(tool) => {
-                        checker::check_or_update_tool(
+                        return checker::check_or_update_tool(
                             input,
                             tool,
                             should_update,
@@ -409,21 +424,15 @@ async fn main() -> ExitCode {
             for x in &executors {
                 let deps = x.get_deps(input).await;
                 for dep in deps {
-                    if !executors
-                        .iter()
-                        .any(|e| e.get_name() == dep.name)
-                        && !to_add
-                            .iter()
-                            .any(|e| e.get_name() == dep.name)
-                        && !processed_deps.contains(&dep.name)
-                    {
+                    let dep_name = canonical_name(&dep.name);
+                    if !dep_satisfied(&executors, &to_add, &processed_deps, &dep_name) {
                         if dep.optional {
                             if which::which(&dep.name).is_ok() {
                                 info!(
                                     "Optional dependency '{}' found in PATH, using system version",
                                     dep.name
                                 );
-                                processed_deps.insert(dep.name.clone());
+                                processed_deps.insert(dep_name.clone());
                                 continue;
                             } else {
                                 info!(
@@ -442,7 +451,7 @@ async fn main() -> ExitCode {
                             gems: None,
                         }) {
                             look_for_deps = true;
-                            processed_deps.insert(dep.name.clone());
+                            processed_deps.insert(dep_name.clone());
                             to_add.push(e);
                         }
                     }
@@ -523,5 +532,42 @@ async fn main() -> ExitCode {
     } else {
         print_help(ver);
         ExitCode::from(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ex(name: &str) -> Box<dyn Executor> {
+        <dyn Executor>::new(ExecutorCmd {
+            cmd: name.to_string(),
+            version: None,
+            distribution: None,
+            include_tags: Default::default(),
+            exclude_tags: Default::default(),
+            gems: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_dep_satisfied_matches_on_registry_name() {
+        let git = vec![ex("git")];
+        let empty: Vec<Box<dyn Executor>> = vec![];
+        let none = std::collections::HashSet::new();
+
+        // The gh -> git case, the one that used to build a second executor
+        assert!(dep_satisfied(&git, &empty, &none, "git"));
+        assert!(dep_satisfied(&empty, &git, &none, "git"));
+
+        // ...without swallowing a dep that really is missing
+        assert!(!dep_satisfied(&git, &empty, &none, "java"));
+        assert!(!dep_satisfied(&empty, &empty, &none, "git"));
+
+        // an optional dep taken from PATH is recorded here, canonically
+        let mut done = std::collections::HashSet::new();
+        done.insert("java".to_string());
+        assert!(dep_satisfied(&empty, &empty, &done, "java"));
     }
 }

--- a/src/stage4/src/tools.rs
+++ b/src/stage4/src/tools.rs
@@ -480,6 +480,25 @@ pub fn get_tool_info(name: &str) -> Option<&'static ToolInfo> {
     TOOL_REGISTRY.get(name)
 }
 
+/// The registry name an executor answers to - what the user types.
+/// get_name() is the repo for github tools (gh -> cli, git -> portable-git)
+/// and the invoked alias for ruby, so comparing against it misses. Going via
+/// the cmd also folds aliases (claude-code -> claude). Falls back to
+/// get_name() for anything not in the registry, like a raw gh/owner/repo.
+pub fn registry_name(executor: &dyn Executor) -> String {
+    get_tool_info(&executor.get_executor_cmd().cmd)
+        .map(|info| info.name.to_string())
+        .unwrap_or_else(|| executor.get_name().to_string())
+}
+
+/// The registry name for a name the user typed, unchanged if it is not a
+/// registered tool (raw gh/owner/repo, or not a tool at all).
+pub fn canonical_name(name: &str) -> String {
+    get_tool_info(name)
+        .map(|info| info.name.to_string())
+        .unwrap_or_else(|| name.to_string())
+}
+
 pub fn get_all_tools() -> Vec<&'static ToolInfo> {
     let mut tools: Vec<_> = TOOL_REGISTRY
         .values()


### PR DESCRIPTION
`gg update <tool>` matched what you typed against executor.get_name(), which is the GitHub repo for the github-backed tools (gh -> cli, git -> portable-git, antigravity -> antigravity-cli), the invoked alias for ruby and the npm spec name for node. So `gg update gh` said "not found in cache" while `gg update cli` worked, and all 14 aliases missed too. The display name came from the same place, so `gg update` listed the repo names - the only ones that happened to work.

registry_name/canonical_name resolve an executor, or a name the user typed, through the tool registry. checker.rs and main.rs share them.

Same root cause in the dependency dedupe: gh declares an optional dep on git, but a built git executor calls itself portable-git, so the dep looked unsatisfied and a second executor was built over the same cache dir and prepped alongside the first. `gg gh:git` with git off PATH downloaded portable-git twice, now once.

Exit codes while in here, since nothing could tell them apart before: everything printed to stdout and exited 0. Not installed yet stays 0 - callers update before they install - and only a name that is not a tool exits 1. An @version that will not parse is an error too, rather than quietly checking every cached version; the gg.toml pin no longer depends on HashMap order; and a failed prep, after the cache dir is already deleted, stops claiming "Successfully updated".