### PR TITLE
Feature/eirikb/windows bootstrap fixes

### DIFF
--- a/src/stage1/stage1.bat
+++ b/src/stage1/stage1.bat
@@ -18,8 +18,26 @@
     )
     if not exist "%GG_CACHE_DIR%" mkdir "%GG_CACHE_DIR%"
     powershell -c "sc m2 ([byte[]](gc '%0' -Encoding Byte | select -Skip AAAA)) -Encoding Byte"
-    tar -zxf m2 -C "%GG_CACHE_DIR%"
+    : Bare "tar" picks up Git's GNU tar from PATH in Git Bash and on CI runners,
+    : which shells out to a separate gzip and reads "C:" as a remote host (#291).
+    : Sysnative first so a 32-bit cmd gets the native bsdtar, not SysWOW64's.
+    set "GG_TAR=tar"
+    if exist "%SystemRoot%\Sysnative\tar.exe" set "GG_TAR=%SystemRoot%\Sysnative\tar.exe"
+    if exist "%SystemRoot%\System32\tar.exe" set "GG_TAR=%SystemRoot%\System32\tar.exe"
+    "%GG_TAR%" -zxf m2 -C "%GG_CACHE_DIR%"
+    set "GG_UNTAR_ERR=%errorlevel%"
     del m2
+    set "GG_TAR="
+    if not "%GG_UNTAR_ERR%"=="0" (
+        echo gg: failed to unpack into "%GG_CACHE_DIR%" ^(tar exit %GG_UNTAR_ERR%^)
+        exit /b %GG_UNTAR_ERR%
+    )
+    : A zero exit does not prove stage2 landed, and handing PowerShell a missing
+    : -file is the confusing error #291 actually reported.
+    if not exist "%GG_CACHE_DIR%\gg-VERVER\stage2.ps1" (
+        echo gg: unpack produced no stage2.ps1 in "%GG_CACHE_DIR%"
+        exit /b 1
+    )
     powershell -executionpolicy bypass -file "%GG_CACHE_DIR%\gg-VERVER\stage2.ps1" %*
     exit /b %errorlevel%
 BATCH

--- a/src/stage1/stage1.bat
+++ b/src/stage1/stage1.bat
@@ -18,24 +18,13 @@
     )
     if not exist "%GG_CACHE_DIR%" mkdir "%GG_CACHE_DIR%"
     powershell -c "sc m2 ([byte[]](gc '%0' -Encoding Byte | select -Skip AAAA)) -Encoding Byte"
-    : Bare "tar" picks up Git's GNU tar from PATH in Git Bash and on CI runners,
-    : which shells out to a separate gzip and reads "C:" as a remote host (#291).
-    : Sysnative first so a 32-bit cmd gets the native bsdtar, not SysWOW64's.
-    set "GG_TAR=tar"
-    if exist "%SystemRoot%\Sysnative\tar.exe" set "GG_TAR=%SystemRoot%\Sysnative\tar.exe"
-    if exist "%SystemRoot%\System32\tar.exe" set "GG_TAR=%SystemRoot%\System32\tar.exe"
+    : Git's GNU tar shadows tar on PATH and cannot take "C:" paths (#291)
+    set "GG_TAR=%SystemRoot%\System32\tar.exe"
+    if not exist "%GG_TAR%" set "GG_TAR=tar"
     "%GG_TAR%" -zxf m2 -C "%GG_CACHE_DIR%"
-    set "GG_UNTAR_ERR=%errorlevel%"
     del m2
-    set "GG_TAR="
-    if not "%GG_UNTAR_ERR%"=="0" (
-        echo gg: failed to unpack into "%GG_CACHE_DIR%" ^(tar exit %GG_UNTAR_ERR%^)
-        exit /b %GG_UNTAR_ERR%
-    )
-    : A zero exit does not prove stage2 landed, and handing PowerShell a missing
-    : -file is the confusing error #291 actually reported.
     if not exist "%GG_CACHE_DIR%\gg-VERVER\stage2.ps1" (
-        echo gg: unpack produced no stage2.ps1 in "%GG_CACHE_DIR%"
+        echo gg: could not unpack into "%GG_CACHE_DIR%"
         exit /b 1
     )
     powershell -executionpolicy bypass -file "%GG_CACHE_DIR%\gg-VERVER\stage2.ps1" %*

--- a/src/stage2/stage2.ps1
+++ b/src/stage2/stage2.ps1
@@ -97,7 +97,20 @@ if ($hash)
             # stage3, so verify ourselves. Catches a tampered blob as well as
             # the boring case: a truncated-but-non-empty download. -ne is
             # case-insensitive, so uppercase vs lowercase hex is fine.
-            $actualHash = (Get-FileHash $tempFile -Algorithm SHA512).Hash
+            # Hash via .NET, not Get-FileHash: that one lives in a script module
+            # which PowerShell 7 shadows with its Core-only copy, so a child
+            # Windows PowerShell can't load it and the cmdlet vanishes (#292).
+            $sha512 = [System.Security.Cryptography.SHA512]::Create()
+            $stream = [System.IO.File]::OpenRead($tempFile)
+            try
+            {
+                $actualHash = [BitConverter]::ToString($sha512.ComputeHash($stream)).Replace('-', '')
+            }
+            finally
+            {
+                $stream.Dispose()
+                $sha512.Dispose()
+            }
             if ($actualHash -ne $hash)
             {
                 Write-Host "Hash mismatch: expected $hash, got $actualHash"


### PR DESCRIPTION
 Both failures only hit the very first run, since stage1 short-circuits to the cached stage2 afterwards, and both come from the bootstrap inheriting a hostile environment: git bash and pwsh run gg.cmd through cmd.exe, so the batch branch executes with the parent shell's PATH and PSModulePath.

stage2.ps1: Get-FileHash lives in a script module, and PowerShell 7 prepends its Core-only copy of Microsoft.PowerShell.Utility to PSModulePath. A child Windows PowerShell then loads that one, keeps the binary cmdlets from the snap-in, and loses the script functions - so Invoke-WebRequest works while Get-FileHash is "not recognized". Hash through .NET instead, which needs no module loading.

stage1.bat: bare tar resolves to Git's GNU tar ahead of System32, which shells out to a separate gzip and reads "C:" as a remote host spec. Pin Windows' own bsdtar. A failed unpack also fell through to powershell -file on a stage2.ps1 that was never written, so the real error was buried under a confusing one - check the exit code and that stage2 actually landed.

Verified on Windows Server 2022 with cold caches: cmd, pwsh 7, git bash and 32-bit cmd with GNU tar first on PATH all bootstrap, and an unwritable cache dir now reports the unpack failure instead of the PowerShell -file error.