### PR TITLE
java: default to Temurin, keep Azul as the fallback

### DIFF
--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -368,6 +368,14 @@ pub async fn prep(
                 .map(|t| format!("e{t}"))
                 .collect::<Vec<String>>()
                 .join("_")
+                .as_str()
+            // Or java@17-azul and java@17-temurin share a dir - and so do java and
+            // java@-jdk, where the "distribution" is really a dropped tag
+            + executor_cmd
+                .distribution
+                .as_ref()
+                .map(|d| format!("d{d}"))
+                .unwrap_or_default()
                 .as_str(),
     );
     let path = path_path.to_str().unwrap();

--- a/src/stage4/src/executors/java.rs
+++ b/src/stage4/src/executors/java.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::executor::{AppInput, AppPath, BinPattern, Download, ExecutorCmd};
 use crate::executors::gradle_properties::GradleAndWrapperProperties;
-use crate::executors::java_distributions::JavaDistributions;
+use crate::executors::java_distributions::{JavaDistributions, FALLBACK_DISTRIBUTION};
 use crate::target::Os;
 use crate::Executor;
 
@@ -19,6 +19,15 @@ struct SdkmanRc {
 
 pub struct Java {
     pub executor_cmd: ExecutorCmd,
+}
+
+fn has_matching_version(downloads: &[Download], version_req: &VersionReq) -> bool {
+    downloads.iter().any(|download| {
+        download
+            .version
+            .as_ref()
+            .is_some_and(|version| version_req.matches(&version.to_version()))
+    })
 }
 
 fn get_jdk_version() -> Option<String> {
@@ -80,7 +89,29 @@ impl Executor for Java {
     ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
         Box::pin(async move {
             let distribution = self.get_distribution();
-            (distribution.handler)(&input.target).await
+            let downloads = (distribution.handler)(&input.target).await;
+
+            // An explicit -azul/-tem is the user's call, so never second-guess it.
+            if self.executor_cmd.distribution.is_some() {
+                return downloads;
+            }
+
+            // Same precedence as the download filtering in executor.rs, so .sdkmanrc and
+            // gradle.properties versions get the fallback too, not just an explicit @14.
+            let version_req = match &self.executor_cmd.version {
+                Some(version_req) => Some(version_req.to_version_req()),
+                None => self.get_version_req(),
+            };
+
+            match version_req {
+                Some(version_req) if !has_matching_version(&downloads, &version_req) => {
+                    match JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION) {
+                        Some(fallback) => (fallback.handler)(&input.target).await,
+                        None => downloads,
+                    }
+                }
+                _ => downloads,
+            }
         })
     }
 

--- a/src/stage4/src/executors/java.rs
+++ b/src/stage4/src/executors/java.rs
@@ -103,15 +103,21 @@ impl Executor for Java {
                 None => self.get_version_req(),
             };
 
-            match version_req {
-                Some(version_req) if !has_matching_version(&downloads, &version_req) => {
-                    match JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION) {
-                        Some(fallback) => (fallback.handler)(&input.target).await,
-                        None => downloads,
-                    }
+            // An unreachable Adoptium comes back as an empty list rather than an error, so
+            // treat that as unsatisfiable too - otherwise a bare `java` (no version to
+            // check against) would be left with nothing while Azul was sitting right there.
+            let needs_fallback = match &version_req {
+                Some(version_req) => !has_matching_version(&downloads, version_req),
+                None => downloads.is_empty(),
+            };
+
+            if needs_fallback {
+                if let Some(fallback) = JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION) {
+                    return (fallback.handler)(&input.target).await;
                 }
-                _ => downloads,
             }
+
+            downloads
         })
     }
 
@@ -160,6 +166,54 @@ mod tests {
     // one test delete another's dir mid-flight.)
     fn create_isolated_test_dir() -> TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    fn downloads_for(versions: &[&str]) -> Vec<Download> {
+        versions
+            .iter()
+            .map(|version| Download::new(format!("http://x/{version}"), version, None))
+            .collect()
+    }
+
+    fn version_req(req: &str) -> VersionReq {
+        crate::executor::GgVersionReq::new(req).unwrap().to_version_req()
+    }
+
+    #[test]
+    fn test_default_distribution_is_temurin() {
+        assert_eq!(JavaDistributions::get_default().name, "temurin");
+    }
+
+    #[test]
+    fn test_fallback_distribution_is_registered() {
+        // The fallback is looked up by name at runtime, so a rename would
+        // otherwise only surface as a silently missing fallback.
+        assert!(JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION).is_some());
+    }
+
+    #[test]
+    fn test_has_matching_version_finds_requested_release() {
+        let downloads = downloads_for(&["17.0.9", "21.0.1"]);
+        assert!(has_matching_version(&downloads, &version_req("21")));
+    }
+
+    #[test]
+    fn test_has_matching_version_misses_release_adoptium_lacks() {
+        // java@14 404s on Adoptium, which is what sends us to Azul.
+        let downloads = downloads_for(&["8.0.392", "17.0.9", "21.0.1"]);
+        assert!(!has_matching_version(&downloads, &version_req("14")));
+    }
+
+    #[test]
+    fn test_has_matching_version_on_empty_downloads() {
+        // An unreachable Adoptium looks like this, not like an error.
+        assert!(!has_matching_version(&[], &version_req("21")));
+    }
+
+    #[test]
+    fn test_has_matching_version_ignores_versionless_downloads() {
+        let downloads = vec![Download::new("http://x/nightly".to_string(), "nightly", None)];
+        assert!(!has_matching_version(&downloads, &version_req("21")));
     }
 
     #[test]

--- a/src/stage4/src/executors/java.rs
+++ b/src/stage4/src/executors/java.rs
@@ -66,6 +66,16 @@ impl Java {
             JavaDistributions::get_default()
         }
     }
+
+    /// `java@-temurin` picks a distribution, `java@-jdk+jre` drops a tag, and both are
+    /// `@-word` - so a name that isn't a registered distribution meant the tag removal.
+    fn dropped_tag(&self) -> Option<&str> {
+        let name = self.executor_cmd.distribution.as_deref()?;
+        match JavaDistributions::get_by_name(name) {
+            Some(_) => None,
+            None => Some(name),
+        }
+    }
 }
 
 impl Executor for Java {
@@ -92,28 +102,34 @@ impl Executor for Java {
             let downloads = (distribution.handler)(&input.target).await;
 
             // An explicit -azul/-tem is the user's call, so never second-guess it.
-            if self.executor_cmd.distribution.is_some() {
+            if self.executor_cmd.distribution.is_some() && self.dropped_tag().is_none() {
                 return downloads;
             }
 
-            // Same precedence as the download filtering in executor.rs, so .sdkmanrc and
-            // gradle.properties versions get the fallback too, not just an explicit @14.
+            // Tags are applied after this, and Temurin has none of the +fx/+headless/+sts
+            // that only Azul publishes - so a version-only check says yes, then matches
+            // nothing.
+            let matches = (self as &dyn Executor).get_url_matches(&downloads, input);
+
+            // Same precedence as executor.rs, and get_url_matches only knows
+            // executor_cmd.version - so .sdkmanrc and gradle.properties land here.
             let version_req = match &self.executor_cmd.version {
                 Some(version_req) => Some(version_req.to_version_req()),
                 None => self.get_version_req(),
             };
 
-            // An unreachable Adoptium comes back as an empty list rather than an error, so
-            // treat that as unsatisfiable too - otherwise a bare `java` (no version to
-            // check against) would be left with nothing while Azul was sitting right there.
             let needs_fallback = match &version_req {
-                Some(version_req) => !has_matching_version(&downloads, version_req),
-                None => downloads.is_empty(),
+                Some(version_req) => !has_matching_version(&matches, version_req),
+                None => matches.is_empty(),
             };
 
             if needs_fallback {
                 if let Some(fallback) = JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION) {
-                    return (fallback.handler)(&input.target).await;
+                    let fallback_downloads = (fallback.handler)(&input.target).await;
+                    // Empty means Azul failed too - keep what we have instead
+                    if !fallback_downloads.is_empty() {
+                        return fallback_downloads;
+                    }
                 }
             }
 
@@ -137,11 +153,29 @@ impl Executor for Java {
 
     fn get_default_include_tags(&self) -> HashSet<String> {
         let distribution = self.get_distribution();
-        distribution
+        let mut tags: HashSet<String> = distribution
             .default_tags
             .into_iter()
             .map(|s| s.to_string())
-            .collect()
+            .collect();
+
+        // Defaults are required tags, so a dropped one has to leave here too, or
+        // java@-jdk+jre wants jre and jdk at once and matches nothing
+        if let Some(tag) = self.dropped_tag() {
+            tags.remove(tag);
+        }
+        for tag in &self.executor_cmd.exclude_tags {
+            tags.remove(tag.as_str());
+        }
+
+        tags
+    }
+
+    fn get_default_exclude_tags(&self) -> HashSet<String> {
+        match self.dropped_tag() {
+            Some(tag) => HashSet::from([tag.to_string()]),
+            None => HashSet::new(),
+        }
     }
 
     fn get_env(&self, app_path: &AppPath) -> HashMap<String, String> {
@@ -176,7 +210,62 @@ mod tests {
     }
 
     fn version_req(req: &str) -> VersionReq {
-        crate::executor::GgVersionReq::new(req).unwrap().to_version_req()
+        crate::executor::GgVersionReq::new(req)
+            .unwrap()
+            .to_version_req()
+    }
+
+    fn java_with(distribution: Option<&str>, include: &[&str], exclude: &[&str]) -> Java {
+        Java {
+            executor_cmd: ExecutorCmd {
+                cmd: "java".to_string(),
+                version: None,
+                distribution: distribution.map(String::from),
+                include_tags: include.iter().map(|s| s.to_string()).collect(),
+                exclude_tags: exclude.iter().map(|s| s.to_string()).collect(),
+                gems: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_real_distribution_is_not_treated_as_a_dropped_tag() {
+        assert_eq!(java_with(Some("temurin"), &[], &[]).dropped_tag(), None);
+    }
+
+    #[test]
+    fn test_unknown_distribution_is_a_dropped_tag() {
+        // java@-jdk+jre parks "jdk" in the distribution slot - same syntax as java@-temurin
+        assert_eq!(
+            java_with(Some("jdk"), &["jre"], &[]).dropped_tag(),
+            Some("jdk")
+        );
+    }
+
+    #[test]
+    fn test_dropped_tag_leaves_defaults_alone_for_a_real_distribution() {
+        let tags = java_with(Some("temurin"), &[], &[]).get_default_include_tags();
+        assert!(tags.contains("jdk"));
+        assert!(java_with(Some("temurin"), &[], &[])
+            .get_default_exclude_tags()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_jre_request_drops_the_default_jdk_tag() {
+        // Both halves matter, or java@-jdk+jre asks for jre while still requiring jdk
+        let java = java_with(Some("jdk"), &["jre"], &[]);
+        let include = java.get_default_include_tags();
+        assert!(!include.contains("jdk"), "jdk should no longer be required");
+        assert!(include.contains("ga"), "unrelated defaults should survive");
+        assert!(java.get_default_exclude_tags().contains("jdk"));
+    }
+
+    #[test]
+    fn test_explicit_exclude_tag_also_drops_the_default() {
+        let include = java_with(None, &[], &["jdk"]).get_default_include_tags();
+        assert!(!include.contains("jdk"));
+        assert!(include.contains("ga"));
     }
 
     #[test]
@@ -186,8 +275,7 @@ mod tests {
 
     #[test]
     fn test_fallback_distribution_is_registered() {
-        // The fallback is looked up by name at runtime, so a rename would
-        // otherwise only surface as a silently missing fallback.
+        // Looked up by name at runtime, so a rename would just lose the fallback quietly
         assert!(JavaDistributions::get_by_name(FALLBACK_DISTRIBUTION).is_some());
     }
 
@@ -212,7 +300,11 @@ mod tests {
 
     #[test]
     fn test_has_matching_version_ignores_versionless_downloads() {
-        let downloads = vec![Download::new("http://x/nightly".to_string(), "nightly", None)];
+        let downloads = vec![Download::new(
+            "http://x/nightly".to_string(),
+            "nightly",
+            None,
+        )];
         assert!(!has_matching_version(&downloads, &version_req("21")));
     }
 

--- a/src/stage4/src/executors/java_distributions.rs
+++ b/src/stage4/src/executors/java_distributions.rs
@@ -20,20 +20,26 @@ pub struct DistributionConfig {
 
 pub struct JavaDistributions;
 
+const DEFAULT_DISTRIBUTION: &str = "temurin";
+
+/// Adoptium only publishes the current LTS and recent feature releases, so `java@14` and
+/// friends 404 there. Azul still carries them, so it backs up the default.
+pub const FALLBACK_DISTRIBUTION: &str = "azul";
+
 impl JavaDistributions {
     pub fn get_all() -> Vec<DistributionConfig> {
         vec![
-            DistributionConfig {
-                name: "azul",
-                short_name: "azul",
-                default_tags: vec!["jdk", "ga"],
-                handler: get_azul_downloads,
-            },
             DistributionConfig {
                 name: "temurin",
                 short_name: "tem",
                 default_tags: vec!["jdk", "ga"],
                 handler: get_temurin_downloads,
+            },
+            DistributionConfig {
+                name: "azul",
+                short_name: "azul",
+                default_tags: vec!["jdk", "ga"],
+                handler: get_azul_downloads,
             },
         ]
     }
@@ -45,7 +51,7 @@ impl JavaDistributions {
     }
 
     pub fn get_default() -> DistributionConfig {
-        Self::get_all().into_iter().next().unwrap()
+        Self::get_by_name(DEFAULT_DISTRIBUTION).expect("default distribution must be registered")
     }
 }
 
@@ -193,115 +199,131 @@ struct TemurinVersionData {
     pub semver: String,
 }
 
-fn get_temurin_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>> {
-    let target = *target;
-    Box::pin(async move {
-        let mut downloads = Vec::new();
+/// Used when api.adoptium.net/v3/info/available_releases can't be reached or parsed.
+const TEMURIN_FALLBACK_VERSIONS: [u32; 5] = [8, 11, 17, 21, 25];
 
-        let available_releases_url = "https://api.adoptium.net/v3/info/available_releases";
-        let versions_to_fetch = match reqwest::get(available_releases_url).await {
-            Ok(response) => match response.text().await {
-                Ok(text) => match serde_json::from_str::<TemurinAvailableReleases>(&text) {
-                    Ok(available) => {
-                        let mut versions = available.available_lts_releases;
-                        if !versions.contains(&available.most_recent_feature_release) {
-                            versions.push(available.most_recent_feature_release);
+async fn get_temurin_available_releases() -> Option<TemurinAvailableReleases> {
+    let text = reqwest::get("https://api.adoptium.net/v3/info/available_releases")
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+async fn get_temurin_version_downloads(target: Target, version: u32, lts: bool) -> Vec<Download> {
+    let url = format!(
+        "https://api.adoptium.net/v3/assets/feature_releases/{}/ga?page_size=20&page=0&jvm_impl=hotspot&vendor=eclipse",
+        version
+    );
+
+    let mut downloads = Vec::new();
+
+    if let Ok(response) = reqwest::get(&url).await {
+        if let Ok(text) = response.text().await {
+            if let Ok(releases) = serde_json::from_str::<Vec<TemurinRelease>>(&text) {
+                for release in releases {
+                    for binary in release.binaries {
+                        if binary.image_type != "jdk" {
+                            continue;
                         }
-                        versions
-                    }
-                    Err(_) => vec![8, 11, 17, 21],
-                },
-                Err(_) => vec![8, 11, 17, 21],
-            },
-            Err(_) => vec![8, 11, 17, 21],
-        };
 
-        for version in versions_to_fetch {
-            let url = format!(
-                "https://api.adoptium.net/v3/assets/feature_releases/{}/ga?page_size=20&page=0&jvm_impl=hotspot&vendor=eclipse",
-                version
-            );
+                        let os_match = match (&target.os, binary.os.as_str()) {
+                            (Os::Windows, "windows") => true,
+                            (Os::Linux, "linux") => target.variant != Some(Variant::Musl),
+                            (Os::Linux, "alpine-linux") => target.variant == Some(Variant::Musl),
+                            (Os::Mac, "mac") => true,
+                            (Os::Any, _) => true,
+                            _ => false,
+                        };
 
-            if let Ok(response) = reqwest::get(&url).await {
-                if let Ok(text) = response.text().await {
-                    if let Ok(releases) = serde_json::from_str::<Vec<TemurinRelease>>(&text) {
-                        for release in releases {
-                            for binary in release.binaries {
-                                if binary.image_type != "jdk" {
-                                    continue;
-                                }
+                        let arch_match = matches!(
+                            (&target.arch, binary.architecture.as_str()),
+                            (Arch::X86_64, "x64")
+                                | (Arch::X86_64, "x86_64")
+                                | (Arch::Arm64, "aarch64")
+                                | (Arch::Arm64, "arm64")
+                                | (Arch::Armv7, "arm")
+                                | (Arch::Any, _)
+                        );
 
-                                let os_match = match (&target.os, binary.os.as_str()) {
-                                    (Os::Windows, "windows") => true,
-                                    (Os::Linux, "linux") => target.variant != Some(Variant::Musl),
-                                    (Os::Linux, "alpine-linux") => {
-                                        target.variant == Some(Variant::Musl)
-                                    }
-                                    (Os::Mac, "mac") => true,
-                                    (Os::Any, _) => true,
-                                    _ => false,
-                                };
+                        if os_match && arch_match {
+                            let mut tags = HashSet::new();
+                            tags.insert(binary.image_type.clone());
+                            tags.insert(release.release_type.clone());
+                            tags.insert(binary.heap_size.clone());
+                            tags.insert(binary.jvm_impl.clone());
+                            tags.insert(format!("java{}", version));
 
-                                let arch_match = matches!(
-                                    (&target.arch, binary.architecture.as_str()),
-                                    (Arch::X86_64, "x64")
-                                        | (Arch::X86_64, "x86_64")
-                                        | (Arch::Arm64, "aarch64")
-                                        | (Arch::Arm64, "arm64")
-                                        | (Arch::Armv7, "arm")
-                                        | (Arch::Any, _)
-                                );
-
-                                if os_match && arch_match {
-                                    let mut tags = HashSet::new();
-                                    tags.insert(binary.image_type.clone());
-                                    tags.insert(release.release_type.clone());
-                                    tags.insert(binary.heap_size.clone());
-                                    tags.insert(binary.jvm_impl.clone());
-                                    tags.insert(format!("java{}", version));
-
-                                    if [8, 11, 17, 21].contains(&version) {
-                                        tags.insert("lts".to_string());
-                                    }
-
-                                    let os = match binary.os.as_str() {
-                                        "windows" => Some(Os::Windows),
-                                        "linux" => Some(Os::Linux),
-                                        "alpine-linux" => Some(Os::Linux),
-                                        "mac" => Some(Os::Mac),
-                                        _ => None,
-                                    };
-
-                                    let arch = match binary.architecture.as_str() {
-                                        "x64" | "x86_64" => Some(Arch::X86_64),
-                                        "aarch64" | "arm64" => Some(Arch::Arm64),
-                                        "arm" => Some(Arch::Armv7),
-                                        "x86" | "x32" => None,
-                                        _ => None,
-                                    };
-
-                                    let variant = if binary.os == "alpine-linux" {
-                                        Some(Variant::Musl)
-                                    } else {
-                                        target.variant
-                                    };
-
-                                    downloads.push(Download {
-                                        download_url: binary.package.link,
-                                        version: GgVersion::new(&release.version_data.semver),
-                                        os,
-                                        arch,
-                                        variant,
-                                        tags,
-                                    });
-                                }
+                            if lts {
+                                tags.insert("lts".to_string());
                             }
+
+                            let os = match binary.os.as_str() {
+                                "windows" => Some(Os::Windows),
+                                "linux" => Some(Os::Linux),
+                                "alpine-linux" => Some(Os::Linux),
+                                "mac" => Some(Os::Mac),
+                                _ => None,
+                            };
+
+                            let arch = match binary.architecture.as_str() {
+                                "x64" | "x86_64" => Some(Arch::X86_64),
+                                "aarch64" | "arm64" => Some(Arch::Arm64),
+                                "arm" => Some(Arch::Armv7),
+                                "x86" | "x32" => None,
+                                _ => None,
+                            };
+
+                            let variant = if binary.os == "alpine-linux" {
+                                Some(Variant::Musl)
+                            } else {
+                                target.variant
+                            };
+
+                            downloads.push(Download {
+                                download_url: binary.package.link,
+                                version: GgVersion::new(&release.version_data.semver),
+                                os,
+                                arch,
+                                variant,
+                                tags,
+                            });
                         }
                     }
                 }
             }
         }
+    }
 
-        downloads
+    downloads
+}
+
+fn get_temurin_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>> {
+    let target = *target;
+    Box::pin(async move {
+        let (versions, lts_versions) = match get_temurin_available_releases().await {
+            Some(available) => {
+                let mut versions = available.available_releases;
+                if !versions.contains(&available.most_recent_feature_release) {
+                    versions.push(available.most_recent_feature_release);
+                }
+                (versions, available.available_lts_releases)
+            }
+            None => (
+                TEMURIN_FALLBACK_VERSIONS.to_vec(),
+                TEMURIN_FALLBACK_VERSIONS.to_vec(),
+            ),
+        };
+
+        // One request per feature release, so fan them out instead of paying for them in sequence.
+        futures_util::future::join_all(versions.into_iter().map(|version| {
+            get_temurin_version_downloads(target, version, lts_versions.contains(&version))
+        }))
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
     })
 }

--- a/src/stage4/src/executors/java_distributions.rs
+++ b/src/stage4/src/executors/java_distributions.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
+use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -88,9 +89,27 @@ struct AzulBundle {
 fn get_azul_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>> {
     let target = *target;
     Box::pin(async move {
-        let json = reqwest::get("https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,release_status,abi,arch,bundle_type,cpu_gen,ext,features,hw_bitness,javafx,latest,os,support_term").await.unwrap().text().await.unwrap();
-        let bundles: Vec<AzulBundle> =
-            serde_json::from_str(json.as_str()).expect("JSON was not well-formatted");
+        // Azul backs the default now, not just an explicit -azul, so a bad day at
+        // admin-ajax.php (it likes answering with HTML) must not panic the whole run
+        let bundles: Vec<AzulBundle> = match reqwest::get("https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,release_status,abi,arch,bundle_type,cpu_gen,ext,features,hw_bitness,javafx,latest,os,support_term").await {
+            Ok(response) => match response.text().await {
+                Ok(text) => match serde_json::from_str(text.as_str()) {
+                    Ok(bundles) => bundles,
+                    Err(e) => {
+                        debug!("Azul returned something that was not bundle JSON: {e}");
+                        return vec![];
+                    }
+                },
+                Err(e) => {
+                    debug!("Could not read the Azul response: {e}");
+                    return vec![];
+                }
+            },
+            Err(e) => {
+                debug!("Could not reach Azul: {e}");
+                return vec![];
+            }
+        };
 
         bundles
             .iter()
@@ -225,7 +244,10 @@ async fn get_temurin_version_downloads(target: Target, version: u32, lts: bool) 
             if let Ok(releases) = serde_json::from_str::<Vec<TemurinRelease>>(&text) {
                 for release in releases {
                     for binary in release.binaries {
-                        if binary.image_type != "jdk" {
+                        // Adoptium also ships sbom/testimage/debugimage/sources/staticlibs,
+                        // which nobody can run. jre stays - image_type becomes a tag, so
+                        // java@-jdk+jre can ask for it
+                        if binary.image_type != "jdk" && binary.image_type != "jre" {
                             continue;
                         }
 


### PR DESCRIPTION
Switches the default JDK distribution from Azul to Temurin, and fixes the selection bugs that turned up while verifying it.

## Why Temurin

Temurin is the most-used OpenJDK build by a wide margin (308M docker pulls vs Zulu's 30M) and `api.adoptium.net` is a documented, versioned API. Azul's is a WordPress `admin-ajax.php` endpoint that returns 6.2MB in ~9s and, when it hands back anything but JSON, panicked the whole run - that alone accounted for a chunk of our red CI.

Adoptium doesn't publish the older feature releases, so `java@14` would 404. Azul stays as the fallback, which keeps `java@14` and the README examples working. An explicit `-azul`/`-tem` is left alone.

Also fetches all available releases instead of just LTS + newest, so `java@20` resolves at all, and takes the lts tag and the offline fallback list from the API rather than a hardcoded `[8, 11, 17, 21]` that had gone stale. That's 13 versions instead of 6, so the requests run concurrently rather than one after the other.

## Fixes that came out of it

**`java@-jdk+jre` never worked** - it's in the README and help output, and it was broken on `main` too, so this part isn't fallout from the switch. Three things had to line up: Adoptium publishes jre images and we discarded them; `-jdk` parses into the *distribution* slot because the syntax is shared with `java@-temurin`; and defaults are required tags, so a dropped one has to leave that set or the request demands jre and jdk at once.

**Cache path ignored the distribution.** Once `-jdk` meant something, `java` and `java@-jdk` shared a directory and a plain `java` could hand you a JRE with no `javac`. Distribution is part of the path now, which also stops `java@17-azul` and `java@17-temurin` aliasing (that one predates this branch).

**The fallback only checked the version**, but tags are applied later. Temurin carries none of the `+fx`/`+headless`/`+sts` that only Azul publishes, so `java@+fx` failed outright instead of falling back. It now asks `get_url_matches`, the same predicate that makes the final call.

**Azul no longer panics** on a bad response, and an empty fallback no longer discards a usable Temurin list.

## Verification

161 unit tests pass. Verified cold on Linux x86_64 - each lands in its own cache dir, and only the JDK ones carry `javac`:

| selector | result |
|---|---|
| `java` | Temurin JDK |
| `java@-jdk` | Temurin JRE |
| `java@-jdk+jre` | Temurin JRE |
| `java@+fx` | Zulu 26.32 (fallback) |
| `java@14` | Zulu 14.29 (fallback) |
| `java@-temurin` | Temurin JDK |

## Known gaps

- `needs_fallback` isn't unit-testable as written (the distribution `handler` is a bare `fn` field), so that decision is only covered end-to-end.
- `zulu` isn't registered as an alias for `azul`, so `java@-zulu` resolves to Temurin. `.sdkmanrc` files spell it that way, so worth deciding before this lands.
- Per-version Temurin fan-out failures are still swallowed silently.