### PR TITLE
Don't panic when somebody else's version index is down

### DIFF
--- a/src/stage4/src/bloody_maven.rs
+++ b/src/stage4/src/bloody_maven.rs
@@ -2,10 +2,12 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
+use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_xml_rs::from_str;
 
 use crate::executor::{Download, GgVersion};
+use crate::fetch::fetch_text;
 use crate::target::{Arch, Os, Variant};
 
 #[derive(Serialize, Deserialize)]
@@ -45,10 +47,17 @@ pub fn get_download_urls_from_maven<'a>(group: &'a str, artifact: &'a str) -> Pi
     Box::pin(async move {
         let root_url = format!("https://repo1.maven.org/maven2/org/{group}/{artifact}");
         let metadata_url = format!("{root_url}/maven-metadata.xml");
-        let body = reqwest::get(metadata_url.clone()).await
-            .expect("Unable to connect to archive.apache.org").text().await
-            .expect("Unable to download maven metadata xml");
-        let root: Metadata = from_str(body.as_str()).expect("XML was not well-formatted");
+        let body = match fetch_text(&metadata_url).await {
+            Some(body) => body,
+            None => return vec![],
+        };
+        let root: Metadata = match from_str(body.as_str()) {
+            Ok(root) => root,
+            Err(e) => {
+                warn!("{metadata_url} did not answer with the maven metadata we expected: {e}");
+                return vec![];
+            }
+        };
 
         root.versioning.versions.version.into_iter().map(|ver| {
             let mut tags = HashSet::new();

--- a/src/stage4/src/checker.rs
+++ b/src/stage4/src/checker.rs
@@ -107,11 +107,13 @@ fn matches_requested_tool(executor: &dyn Executor, tool_name: &str, requested_na
         || executor.get_executor_cmd().cmd == tool_name
 }
 
+/// `Err` is "could not read the version list", not "nothing newer" - calling a tool up
+/// to date because the index was down tells someone their old build is the current one.
 async fn check_tool_update(
     meta: GgMeta,
     path: std::path::PathBuf,
     input: &AppInput,
-) -> Option<UpdateInfo> {
+) -> Result<Option<UpdateInfo>, String> {
     info!(
         "Checking tool update for cmd: {:?} with version: {:?}",
         meta.cmd.cmd, meta.cmd.version
@@ -129,6 +131,12 @@ async fn check_tool_update(
             executor.get_name(),
             meta.cmd.cmd
         );
+        if urls.is_empty() {
+            return Err(format!(
+                "{}: could not read the version list",
+                registry_name(&*executor)
+            ));
+        }
         let urls_matches = executor.get_url_matches(&urls, input);
         info!(
             "Got {} url matches for {}",
@@ -155,7 +163,7 @@ async fn check_tool_update(
 
             let version_selector = meta.cmd.to_version_selector();
 
-            return Some(UpdateInfo {
+            return Ok(Some(UpdateInfo {
                 tool_name: registry_name(&*executor),
                 version_selector,
                 current_version: current_version.map(|v| v.to_string()),
@@ -164,10 +172,10 @@ async fn check_tool_update(
                 is_major_update,
                 path,
                 executor,
-            });
+            }));
         }
     }
-    None
+    Ok(None)
 }
 
 fn should_include_update(update_info: &UpdateInfo, allow_major: bool) -> bool {
@@ -208,7 +216,7 @@ pub async fn check_or_update_all_including_gg(
     should_update: bool,
     allow_major: bool,
     force: bool,
-) {
+) -> ExitCode {
     if should_update {
         updater::perform_update(gg_version, force).await;
     } else {
@@ -216,7 +224,7 @@ pub async fn check_or_update_all_including_gg(
     }
     println!();
 
-    check_or_update_all(input, should_update, allow_major, force).await;
+    check_or_update_all(input, should_update, allow_major, force).await
 }
 
 pub async fn check_or_update_all(
@@ -224,12 +232,13 @@ pub async fn check_or_update_all(
     should_update: bool,
     allow_major: bool,
     force: bool,
-) {
+) -> ExitCode {
+    let mut update_failed = false;
     let metas = get_all_tool_metas().await;
 
     if metas.is_empty() {
         println!("No cached tools found.");
-        return;
+        return ExitCode::from(0);
     }
 
     println!("Checking for updates...");
@@ -276,9 +285,11 @@ pub async fn check_or_update_all(
                 let spinner_key = path.to_string_lossy().to_string();
                 let result = check_tool_update(meta, path, input).await;
 
-                if result.is_some() {
-                    if let Some(pb) = tool_spinners.get(&spinner_key) {
-                        pb.finish_with_message("done");
+                if let Some(pb) = tool_spinners.get(&spinner_key) {
+                    match &result {
+                        Ok(Some(_)) => pb.finish_with_message("done"),
+                        Ok(None) => pb.finish_and_clear(),
+                        Err(_) => pb.finish_with_message("could not check"),
                     }
                 }
 
@@ -287,7 +298,15 @@ pub async fn check_or_update_all(
         })
         .collect();
 
-    let update_infos: Vec<UpdateInfo> = join_all(check_tasks).await.into_iter().flatten().collect();
+    let mut check_failures: Vec<String> = Vec::new();
+    let mut update_infos: Vec<UpdateInfo> = Vec::new();
+    for result in join_all(check_tasks).await {
+        match result {
+            Ok(Some(info)) => update_infos.push(info),
+            Ok(None) => {}
+            Err(reason) => check_failures.push(reason),
+        }
+    }
 
     m.clear().unwrap();
 
@@ -337,9 +356,20 @@ pub async fn check_or_update_all(
         }
     }
 
+    if !check_failures.is_empty() {
+        eprintln!();
+        for reason in &check_failures {
+            eprintln!("Could not check for updates - {reason}");
+        }
+    }
+
     if filtered_updates.is_empty() {
-        println!("\nAll tools are up to date!");
-        return;
+        if check_failures.is_empty() {
+            println!("\nAll tools are up to date!");
+            return ExitCode::from(0);
+        }
+        println!("\nEverything we could check is up to date.");
+        return ExitCode::from(1);
     }
 
     if !should_update {
@@ -359,15 +389,29 @@ pub async fn check_or_update_all(
             if let Some(parent) = info.path.parent() {
                 if fs::remove_dir_all(parent).is_ok() {
                     let pb = create_barus();
-                    let _ = prep(&*info.executor, input, &pb).await;
-                    println!("Successfully updated {}", info.tool_name);
+                    // Cache dir is already gone, so swallowing this loses the tool
+                    match prep(&*info.executor, input, &pb).await {
+                        Ok(_) => println!("Successfully updated {}", info.tool_name),
+                        Err(e) => {
+                            eprintln!("Failed to update {}: {}", info.tool_name, e);
+                            update_failed = true;
+                        }
+                    }
                 } else {
-                    println!("Unable to update {}", info.tool_name);
+                    eprintln!("Unable to update {}", info.tool_name);
+                    update_failed = true;
                 }
             } else {
-                println!("Unable to update {}", info.tool_name);
+                eprintln!("Unable to update {}", info.tool_name);
+                update_failed = true;
             }
         }
+    }
+
+    if update_failed {
+        ExitCode::from(1)
+    } else {
+        ExitCode::from(0)
     }
 }
 
@@ -453,7 +497,16 @@ pub async fn check_or_update_tool(
     let mut update_failed = false;
 
     for (meta, path) in matching_metas {
-        if let Some(info) = check_tool_update(meta, path, input).await {
+        let checked = match check_tool_update(meta, path, input).await {
+            Ok(checked) => checked,
+            Err(reason) => {
+                // Keep going - another cached copy of the same tool may check fine
+                eprintln!("Could not check for updates - {reason}");
+                update_failed = true;
+                continue;
+            }
+        };
+        if let Some(info) = checked {
             let display_name = if info.version_selector.is_empty() {
                 info.tool_name.clone()
             } else {

--- a/src/stage4/src/executor.rs
+++ b/src/stage4/src/executor.rs
@@ -433,7 +433,12 @@ pub async fn prep(
         for reason in crate::github_utils::take_github_errors() {
             eprintln!("{reason}");
         }
-        panic!("Did not find any download URL!");
+        // Someone else's site being down is not a bug in gg (#272). Any warning from
+        // fetch.rs is right above this with the real reason.
+        return Err(format!(
+            "Did not find any download URL for {}. The version list may be unreachable - run with -v for details.",
+            executor.get_name()
+        ));
     }
 
     let urls_match = get_url_matches(&urls, input, executor);
@@ -819,6 +824,58 @@ pub async fn try_run(
 mod tests {
     use super::*;
     use crate::github_utils::{detect_arch_from_name, detect_os_from_name};
+
+    /// An executor whose index is down: no URLs, no explanation.
+    struct NoUrls {
+        cmd: ExecutorCmd,
+    }
+
+    impl Executor for NoUrls {
+        fn get_executor_cmd(&self) -> &ExecutorCmd {
+            &self.cmd
+        }
+        fn get_download_urls<'a>(
+            &'a self,
+            _input: &'a AppInput,
+        ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
+            Box::pin(async { vec![] })
+        }
+        fn get_bins(&self, _input: &AppInput) -> Vec<BinPattern> {
+            vec![BinPattern::Exact("nope".to_string())]
+        }
+        fn get_name(&self) -> &str {
+            "nope"
+        }
+    }
+
+    // Used to be panic!("Did not find any download URL!") - that is #272
+    #[tokio::test]
+    async fn test_prep_errors_instead_of_panicking_when_there_are_no_urls() {
+        let executor = NoUrls {
+            cmd: ExecutorCmd {
+                cmd: "nope".to_string(),
+                version: None,
+                distribution: None,
+                include_tags: Default::default(),
+                exclude_tags: Default::default(),
+                gems: None,
+            },
+        };
+        let input = AppInput {
+            target: Target {
+                arch: Arch::X86_64,
+                os: Os::Linux,
+                variant: None,
+            },
+            app_args: vec![],
+        };
+        let result = prep(&executor, &input, &ProgressBar::hidden()).await;
+        let message = result.err().expect("empty url list must not be Ok");
+        assert!(
+            message.contains("nope"),
+            "the tool should be named: {message}"
+        );
+    }
 
     #[test]
     fn test_find_jar_file_skips_companions_and_is_deterministic() {

--- a/src/stage4/src/executors/go.rs
+++ b/src/stage4/src/executors/go.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::executor::{AppInput, BinPattern, Download, Executor, ExecutorCmd, GgVersion};
+use crate::fetch::fetch_text;
 use crate::target::Arch::{Arm64, X86_64};
 use crate::target::Os::{Linux, Mac, Windows};
 use crate::target::Variant::Any;
@@ -67,12 +68,10 @@ impl Executor for Go {
     ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
         Box::pin(async move {
             // let mut downloads: Vec<Download> = vec!();
-            let body = reqwest::get("https://go.dev/dl/")
-                .await
-                .expect("Unable to connect to go.dev")
-                .text()
-                .await
-                .expect("Unable to download gradle list of versions");
+            let body = match fetch_text("https://go.dev/dl/").await {
+                Some(body) => body,
+                None => return vec![],
+            };
 
             let document = Html::parse_document(body.as_str());
             let downloads: Vec<Download> = document

--- a/src/stage4/src/executors/gradle.rs
+++ b/src/stage4/src/executors/gradle.rs
@@ -9,6 +9,7 @@ use sha256::try_digest;
 
 use crate::executor::{java_deps, AppInput, BinPattern, Download, ExecutorCmd, ExecutorDep};
 use crate::executors::gradle_properties::GradleAndWrapperProperties;
+use crate::fetch::fetch_text;
 use crate::target::Variant;
 use crate::{target, Executor};
 
@@ -53,12 +54,10 @@ impl Executor for Gradle {
                 }
             }
 
-            let body = reqwest::get("https://gradle.org/releases")
-                .await
-                .expect("Unable to connect to services.gradle.org")
-                .text()
-                .await
-                .expect("Unable to download gradle list of versions");
+            let body = match fetch_text("https://gradle.org/releases").await {
+                Some(body) => body,
+                None => return vec![],
+            };
 
             let document = Html::parse_document(body.as_str());
             document

--- a/src/stage4/src/executors/java_distributions.rs
+++ b/src/stage4/src/executors/java_distributions.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
-use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::executor::{Download, GgVersion};
+use crate::fetch::fetch_json;
 use crate::target::{Arch, Os, Target, Variant};
 
 type DistributionHandler = fn(&Target) -> Pin<Box<dyn Future<Output = Vec<Download>> + Send>>;
@@ -91,24 +91,9 @@ fn get_azul_downloads(target: &Target) -> Pin<Box<dyn Future<Output = Vec<Downlo
     Box::pin(async move {
         // Azul backs the default now, not just an explicit -azul, so a bad day at
         // admin-ajax.php (it likes answering with HTML) must not panic the whole run
-        let bundles: Vec<AzulBundle> = match reqwest::get("https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,release_status,abi,arch,bundle_type,cpu_gen,ext,features,hw_bitness,javafx,latest,os,support_term").await {
-            Ok(response) => match response.text().await {
-                Ok(text) => match serde_json::from_str(text.as_str()) {
-                    Ok(bundles) => bundles,
-                    Err(e) => {
-                        debug!("Azul returned something that was not bundle JSON: {e}");
-                        return vec![];
-                    }
-                },
-                Err(e) => {
-                    debug!("Could not read the Azul response: {e}");
-                    return vec![];
-                }
-            },
-            Err(e) => {
-                debug!("Could not reach Azul: {e}");
-                return vec![];
-            }
+        let bundles: Vec<AzulBundle> = match fetch_json("https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,release_status,abi,arch,bundle_type,cpu_gen,ext,features,hw_bitness,javafx,latest,os,support_term").await {
+            Some(bundles) => bundles,
+            None => return vec![],
         };
 
         bundles

--- a/src/stage4/src/executors/node.rs
+++ b/src/stage4/src/executors/node.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::executor::{AppInput, BinPattern, Download, Executor, ExecutorCmd, GgVersion};
+use crate::fetch::fetch_json;
 use crate::target::{Arch, Os, Target, Variant};
 
 type Root = Vec<Root2>;
@@ -223,13 +224,13 @@ async fn download_urls(host: &str, target: &Target) -> Vec<Download> {
         (Os::Mac, Arch::Arm64, _) => "osx-arm64-tar",
         _ => "linux-x64",
     };
-    let json = reqwest::get(format!("https://{host}/download/release/index.json"))
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-    let root: Root = serde_json::from_str(json.as_str()).expect("JSON was not well-formatted");
+    // The musl builds only live on unofficial-builds.nodejs.org, a community box
+    // that goes away now and then
+    let url = format!("https://{host}/download/release/index.json");
+    let root: Root = match fetch_json(&url).await {
+        Some(root) => root,
+        None => return vec![],
+    };
 
     root.iter().filter(|r|
         r.files.contains(&file.to_string())

--- a/src/stage4/src/executors/rat.rs
+++ b/src/stage4/src/executors/rat.rs
@@ -6,6 +6,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::pin::Pin;
 
 use crate::executor::{AppInput, BinPattern, Download, Executor, ExecutorCmd, GgVersion};
+use crate::fetch::fetch_json;
 use crate::target::{Arch, Os, Variant};
 
 pub struct Rat {
@@ -23,12 +24,10 @@ impl Executor for Rat {
     ) -> Pin<Box<dyn Future<Output = Vec<Download>> + 'a>> {
         Box::pin(async move {
             let versions: Vec<String> =
-                reqwest::get("https://ratbinsa.z1.web.core.windows.net/list.json")
-                    .await
-                    .unwrap()
-                    .json()
-                    .await
-                    .unwrap();
+                match fetch_json("https://ratbinsa.z1.web.core.windows.net/list.json").await {
+                    Some(versions) => versions,
+                    None => return vec![],
+                };
             versions
                 .into_iter()
                 .map(|name| {

--- a/src/stage4/src/fetch.rs
+++ b/src/stage4/src/fetch.rs
@@ -83,12 +83,18 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             if let Ok((mut socket, _)) = listener.accept().await {
-                use tokio::io::AsyncWriteExt;
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                // Read the request off the socket before answering. Closing with
+                // bytes still unread gets us an RST on Windows, and the response
+                // we just wrote is thrown away with it
+                let mut request = [0u8; 2048];
+                let _ = socket.read(&mut request).await;
                 let response = format!(
                     "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                     body.len()
                 );
                 let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.flush().await;
                 let _ = socket.shutdown().await;
             }
         });

--- a/src/stage4/src/fetch.rs
+++ b/src/stage4/src/fetch.rs
@@ -1,0 +1,116 @@
+use log::warn;
+use serde::de::DeserializeOwned;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+/// A refused connection is quick, but a host that just swallows packets would leave
+/// gg spinning forever - worse than the panic this replaced.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .unwrap_or_default()
+});
+
+/// GET a URL and hand back the body. Someone else's index being down is a bad day, not
+/// a reason to panic. Warn level, so the reason shows up without -v.
+pub async fn fetch_text(url: &str) -> Option<String> {
+    let response = match CLIENT.get(url).send().await {
+        Ok(response) => response,
+        Err(e) => {
+            warn!("Could not reach {url}: {e}");
+            return None;
+        }
+    };
+
+    // Without this a 503 holding page is just a body, and the scrapers quietly
+    // parse zero links out of it
+    let response = match response.error_for_status() {
+        Ok(response) => response,
+        Err(e) => {
+            warn!("{url} answered with {e}");
+            return None;
+        }
+    };
+
+    match response.text().await {
+        Ok(text) => Some(text),
+        Err(e) => {
+            warn!("Could not read the response from {url}: {e}");
+            None
+        }
+    }
+}
+
+/// Same deal for the endpoints handing back JSON.
+pub async fn fetch_json<T: DeserializeOwned>(url: &str) -> Option<T> {
+    let text = fetch_text(url).await?;
+
+    match serde_json::from_str(&text) {
+        Ok(value) => Some(value),
+        Err(e) => {
+            warn!("{url} did not answer with the JSON we expected: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Port 1 refuses right away, so this is the dead-host case without the wait
+    const DEAD: &str = "http://127.0.0.1:1/index.json";
+
+    #[tokio::test]
+    async fn test_fetch_text_returns_none_when_the_host_is_dead() {
+        assert_eq!(fetch_text(DEAD).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_json_returns_none_when_the_host_is_dead() {
+        assert_eq!(fetch_json::<Vec<String>>(DEAD).await, None);
+    }
+
+    /// Answers one request, then goes away. Local, so the tests do not lean on
+    /// somebody else's uptime - the thing this module exists to survive.
+    async fn one_shot_server(status_line: &'static str, body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        format!("http://{addr}/index.json")
+    }
+
+    // A 503 holding page used to come back as a perfectly good body
+    #[tokio::test]
+    async fn test_fetch_text_returns_none_on_error_status() {
+        let url = one_shot_server("503 Service Unavailable", "<html>maintenance</html>").await;
+        assert_eq!(fetch_text(&url).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_text_returns_the_body_on_200() {
+        let url = one_shot_server("200 OK", "hello").await;
+        assert_eq!(fetch_text(&url).await.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_json_returns_none_on_junk_body() {
+        let url = one_shot_server("200 OK", "<html>not json</html>").await;
+        assert_eq!(fetch_json::<Vec<String>>(&url).await, None);
+    }
+}

--- a/src/stage4/src/main.rs
+++ b/src/stage4/src/main.rs
@@ -23,6 +23,7 @@ mod cli;
 mod config;
 mod executor;
 mod executors;
+mod fetch;
 mod gem_utils;
 mod github_utils;
 mod target;
@@ -313,7 +314,7 @@ async fn main() -> ExitCode {
 
                 match tool_name.as_deref() {
                     None => {
-                        checker::check_or_update_all_including_gg(
+                        return checker::check_or_update_all_including_gg(
                             input,
                             ver,
                             should_update,


### PR DESCRIPTION
CI lost an afternoon to this: unofficial-builds.nodejs.org went away for a few hours and the alpine job died with a hyper_util panic, which reads like a bug in gg. It wasn't, and three re-runs later it still wasn't. That is the same shape as the report in #272.

New fetch.rs wraps the GET: fetch_text/fetch_json hand back None instead of unwrapping, and warn with the URL and the reason. Warn is the default level, so you get the real cause without knowing to pass -v. The client also has connect and request timeouts - a host that swallows packets used to leave gg spinning forever, which is worse than the panic it replaced - and error_for_status, or a 503 holding page is just a body the scrapers quietly parse zero links out of.

node, go, gradle, rat, maven and azul go through it now. prep no longer panics with "Did not find any download URL!" either; it says which tool and that the list may be unreachable, with the warning above it carrying the detail.

Two places were quietly turning a dead index into good news. `update` reported "All tools are up to date!" and exit 0 when it could not read a single version list, so check_tool_update now separates "could not check" from "nothing newer". And `update -u` for all tools deleted the cache dir, dropped prep's Err on the floor and printed "Successfully updated" - the single-tool path already knew better, the all-tools path did not.

Still panics past this point: a 404 asset or a truncated archive dies in bloody_indiana_jones, and about eight other fetch sites are still hand-rolled and silent. Those are for later.