### PR TITLE
ci: run the bootstrap from pwsh and git bash

### DIFF
--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -462,11 +462,9 @@ jobs:
   # gg.cmd ends up in cmd.exe whatever you start it from, and inherits that shell's
   # PATH and PSModulePath - that is how #291 (Git's GNU tar ahead of the System32
   # one) and #292 (pwsh shadows the module Get-FileHash lives in) got out, since
-  # test-batch starts from cmd and test-OS1 says `sh gg.cmd`. Only the first run
-  # downloads stage2, and only a run with the secret has a stage4 blob to fetch.
+  # test-batch starts from cmd and test-OS1 says `sh gg.cmd`.
   test-parent-shells:
     needs: [ stage1, hash ]
-    if: needs.hash.outputs.has_secret == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -481,27 +479,50 @@ jobs:
         with:
           name: gg.cmd
 
-      - name: Wipe the cache, or this is not a first run
+      # Without the secret there is no uploaded blob for stage2 to fetch, so seed
+      # stage4 the way the other jobs do rather than skipping the job. stage1
+      # still unpacks - which is where #291 lives - only the download is skipped
+      - name: Download stage4
+        if: needs.hash.outputs.has_secret != 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: stage4_x86_64-pc-windows-msvc
+
+      - name: Pre-populate cache with stage4
+        if: needs.hash.outputs.has_secret != 'true'
         shell: bash
-        # Both roots, since the bat branch reads %UserProfile% and the sh branch
-        # $HOME. Fresh VM every time, so this is belt and braces
         run: |
-          rm -rf "$USERPROFILE/.cache/gg"
-          rm -rf "$HOME/.cache/gg"
+          mkdir -p "$USERPROFILE/.cache/gg/gg-dev"
+          echo "x86_64-pc-windows-msvc" > "$USERPROFILE/.cache/gg/gg-dev/system"
+          cp stage4 "$USERPROFILE/.cache/gg/gg-dev/stage4.exe"
+
+      # stage1.bat only unpacks when it finds no stage2.ps1, so an inherited
+      # cache would skip the very thing this job exists to run
+      - name: No cached stage2, or the unpack never happens
+        shell: bash
+        run: |
+          rm -rf "$USERPROFILE/.cache/gg/gg-dev/stage2.ps1"
+          [ ! -e "$USERPROFILE/.cache/gg/gg-dev/stage2.ps1" ] || { echo "still cached, not a first run"; exit 1; }
 
       - name: Run from pwsh
         if: matrix.parent == 'pwsh'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Twice, like the other test jobs - the second run takes the cached
-        # branch in stage1.bat, which nothing else here covers. pwsh keeps going
-        # after a failed native command, so check before the warm run hides it
+        # Twice, like the other jobs - the second run takes the cached branch in
+        # stage1.bat. pwsh does not stop on a failed native command, and
+        # stage2.ps1 defaults $exitCode to 0 when Start-Process made no process,
+        # so check the code and what node actually printed
         run: |
-          .\gg.cmd -v node -v
+          $out = (.\gg.cmd -v node -v 2>&1 | Out-String)
+          Write-Host $out
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          echo "Nice, let's try again"
-          .\gg.cmd -v node -v
+          if ($out -notmatch '(?m)^v[0-9]+\.[0-9]') { Write-Host "gg exited 0 but node never printed a version"; exit 1 }
+          Write-Host "Nice, let's try again"
+          $out = (.\gg.cmd -v node -v 2>&1 | Out-String)
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($out -notmatch '(?m)^v[0-9]+\.[0-9]') { Write-Host "gg exited 0 but node never printed a version"; exit 1 }
 
       # ./gg.cmd, not `sh gg.cmd` - MSYS hands a .cmd to cmd.exe by extension,
       # which is the point. `sh` would take the other branch and prove nothing
@@ -511,9 +532,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ./gg.cmd -v node -v
+          out=$(./gg.cmd -v node -v 2>&1)
+          echo "$out"
+          echo "$out" | grep -Eq '^v[0-9]+\.[0-9]' || { echo "gg exited 0 but node never printed a version"; exit 1; }
           echo "Nice, let's try again"
-          ./gg.cmd -v node -v
+          out=$(./gg.cmd -v node -v 2>&1)
+          echo "$out"
+          echo "$out" | grep -Eq '^v[0-9]+\.[0-9]' || { echo "gg exited 0 but node never printed a version"; exit 1; }
 
   test-container:
     needs: [ stage1, hash ]
@@ -592,10 +617,8 @@ jobs:
           echo "test-container: ${{ needs.test-container.result }}"
           if [ "${{ needs.test-container.result }}" != "success" ]; then FAILED=1; fi
 
-          # Skipped is fine here and only here - without the secret there is no
-          # stage4 blob to bootstrap from, so the job cannot run at all
           echo "test-parent-shells: ${{ needs.test-parent-shells.result }}"
-          if [ "${{ needs.test-parent-shells.result }}" != "success" ] && [ "${{ needs.test-parent-shells.result }}" != "skipped" ]; then FAILED=1; fi
+          if [ "${{ needs.test-parent-shells.result }}" != "success" ]; then FAILED=1; fi
 
           if [ $FAILED -eq 1 ]; then
             echo "::error::One or more test jobs failed or were skipped"

--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -483,8 +483,8 @@ jobs:
 
       - name: Wipe the cache, or this is not a first run
         shell: bash
-        # Both, since the bat branch keys off %UserProfile% and the sh branch off
-        # $HOME, and those are not the same place on a runner
+        # Both roots, since the bat branch reads %UserProfile% and the sh branch
+        # $HOME. Fresh VM every time, so this is belt and braces
         run: |
           rm -rf "$USERPROFILE/.cache/gg"
           rm -rf "$HOME/.cache/gg"
@@ -494,16 +494,26 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: .\gg.cmd -v node -v
+        # Twice, like the other test jobs - the second run takes the cached
+        # branch in stage1.bat, which nothing else here covers. pwsh keeps going
+        # after a failed native command, so check before the warm run hides it
+        run: |
+          .\gg.cmd -v node -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          echo "Nice, let's try again"
+          .\gg.cmd -v node -v
 
-      # ./gg.cmd, not `sh gg.cmd` - bash hands a .cmd to cmd.exe, which is the
-      # whole point. `sh` would take the other branch and prove nothing here
+      # ./gg.cmd, not `sh gg.cmd` - MSYS hands a .cmd to cmd.exe by extension,
+      # which is the point. `sh` would take the other branch and prove nothing
       - name: Run from git bash
         if: matrix.parent == 'bash'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./gg.cmd -v node -v
+        run: |
+          ./gg.cmd -v node -v
+          echo "Nice, let's try again"
+          ./gg.cmd -v node -v
 
   test-container:
     needs: [ stage1, hash ]

--- a/.github/workflows/gg.yml
+++ b/.github/workflows/gg.yml
@@ -458,7 +458,52 @@ jobs:
         run: |
           .\gg.cmd -V
           echo Exit code was %errorlevel%
-  
+
+  # gg.cmd ends up in cmd.exe whatever you start it from, and inherits that shell's
+  # PATH and PSModulePath - that is how #291 (Git's GNU tar ahead of the System32
+  # one) and #292 (pwsh shadows the module Get-FileHash lives in) got out, since
+  # test-batch starts from cmd and test-OS1 says `sh gg.cmd`. Only the first run
+  # downloads stage2, and only a run with the secret has a stage4 blob to fetch.
+  test-parent-shells:
+    needs: [ stage1, hash ]
+    if: needs.hash.outputs.has_secret == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        # `shell:` takes no expressions, so this only picks which step is live -
+        # still one job per parent shell, so a break says which shell broke
+        parent: [ pwsh, bash ]
+
+    runs-on: windows-2022
+    steps:
+      - name: Download gg
+        uses: actions/download-artifact@v8
+        with:
+          name: gg.cmd
+
+      - name: Wipe the cache, or this is not a first run
+        shell: bash
+        # Both, since the bat branch keys off %UserProfile% and the sh branch off
+        # $HOME, and those are not the same place on a runner
+        run: |
+          rm -rf "$USERPROFILE/.cache/gg"
+          rm -rf "$HOME/.cache/gg"
+
+      - name: Run from pwsh
+        if: matrix.parent == 'pwsh'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .\gg.cmd -v node -v
+
+      # ./gg.cmd, not `sh gg.cmd` - bash hands a .cmd to cmd.exe, which is the
+      # whole point. `sh` would take the other branch and prove nothing here
+      - name: Run from git bash
+        if: matrix.parent == 'bash'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./gg.cmd -v node -v
 
   test-container:
     needs: [ stage1, hash ]
@@ -512,7 +557,7 @@ jobs:
 
   # GitHub Actions hate me :/
   gatekeeper:
-    needs: [ test-OS1, test-OS2, test-OS3, test-batch, test-container ]
+    needs: [ test-OS1, test-OS2, test-OS3, test-batch, test-parent-shells, test-container ]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -536,6 +581,11 @@ jobs:
 
           echo "test-container: ${{ needs.test-container.result }}"
           if [ "${{ needs.test-container.result }}" != "success" ]; then FAILED=1; fi
+
+          # Skipped is fine here and only here - without the secret there is no
+          # stage4 blob to bootstrap from, so the job cannot run at all
+          echo "test-parent-shells: ${{ needs.test-parent-shells.result }}"
+          if [ "${{ needs.test-parent-shells.result }}" != "success" ] && [ "${{ needs.test-parent-shells.result }}" != "skipped" ]; then FAILED=1; fi
 
           if [ $FAILED -eq 1 ]; then
             echo "::error::One or more test jobs failed or were skipped"


### PR DESCRIPTION
`gg.cmd` always ends up executing through `cmd.exe` on Windows, but it inherits the `PATH` and `PSModulePath` of whatever shell you started it from. Two bugs shipped through that seam this week:

- **#291** — from Git Bash, `C:\Program Files\Git\usr\bin` sits ahead of `System32`, so a bare `tar` resolved to Git's GNU tar instead of bsdtar. Unpacking died.
- **#292** — from PowerShell 7, the child Windows PowerShell inherits pwsh's `PSModulePath` and loads its Core-only `Microsoft.PowerShell.Utility`. Binary cmdlets kept working; `Get-FileHash` vanished.

Neither was caught, and not for the reason I first assumed. The cold path *was* already tested — `has_secret` is true on same-repo PRs, so "Pre-populate cache with stage4" is skipped there. The actual gap is the **parent shell**:

| Job | Shell | Invocation | Branch exercised |
|---|---|---|---|
| `test-OS1` | `bash` | `sh gg.cmd` | the *shell* half — `sh` is explicit, cmd.exe never sees it |
| `test-batch` | `cmd` | `.\gg.cmd` | the batch half, but parent is plain `cmd.exe` |

So the batch half was covered and Git Bash was covered, but never Git Bash *as parent of* the batch half. Both bugs live in that cell.

## What this adds

`test-parent-shells`: one job per parent shell on `windows-2022`, running `.\gg.cmd` from pwsh and `./gg.cmd` from Git Bash — deliberately not `sh gg.cmd`, since MSYS dispatching a `.cmd` to `cmd.exe` by extension is the whole point.

Each leg runs twice (cold, then the cached branch at `stage1.bat:15`, which nothing else covered) and asserts **what node printed**, not just the exit code — `stage2.ps1` runs `Start-Process -ErrorAction SilentlyContinue` and its catch defaults `$exitCode = 0`, so gg can exit 0 having launched nothing.

The job always runs. When the Azure secret is absent it seeds stage4 from the artifact like the sibling jobs, so fork PRs still cover stage1's unpack — where #291 lives — with only the blob download dropping out. The gatekeeper is strict; no skip exemption.

## Verified

Dispatched on real runners: **178 jobs green, 0 failures.** Both legs cold-bootstrapped (`node not found in cache` → download → `v26.5.0`), then ran warm. The Git Bash leg's own PATH dump confirms the hazard is live there:

```
PATH: …;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;…;C:\Windows\system32;…
```

`actionlint` reports the same findings as `main` (7 pre-existing shellcheck items) — nothing new.

## Honest limits

- **The pwsh leg is a real regression test** — revert the .NET SHA512 to `Get-FileHash` and it goes red deterministically. **The bash leg is weaker**: it proves Git's GNU tar is first on `PATH`, but with the `System32` pin in place GNU tar is never invoked, so reverting the pin might leave it green. It guards the environment more than that specific bug.
- **The fork path is unexercised by these runs** — a same-repo dispatch has the secret, so the seeding steps skip. Only a real fork PR exercises them.
- **The assertions are unproven as detectors** — green shows they don't false-positive; it doesn't show they'd catch the swallowed-exit-code case.
- Not done, worth a follow-up: `timeout-minutes` (the job hits the Azure blob cold every run, and `stage2.ps1:92` has no `-TimeoutSec` or retry), and preconditions asserting the job still reproduces its own premise — Git's tar still shadowing `System32`, pwsh still ≥ 7.